### PR TITLE
Add TLS options for running both with TLS and without on the same time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ glauth.cfg
 
 # Ignore the built binary during testing
 glauth
+
+# Ignore generated certs in this folder
+certs/

--- a/sample-simple.cfg
+++ b/sample-simple.cfg
@@ -5,14 +5,28 @@
 # General configuration.
 debug = true
 #syslog = true
-
 #################
+
 # The frontend section controls how clients connect to the proxy.
 [frontend]
-  tls = false # enable TLS for production!!
+  # LDAP bind address
   listen = "localhost:3893"
-  cert = "cert.pem"
-  key = "key.pem"
+  
+  # If set to true and TLS is enabled, only requests over TLS will be served.
+  # If set to false while TLS is enabled, both TLS and non-encrypted requests will be served.
+  # Set to true by default
+  tlsexclusive = true
+  
+  # TLS options
+  [frontend.tls]
+    # TLS support - enabled by default
+    enabled = false # Important! Enable TLS on production - enabled by default
+
+    # LDAPS bind address - if none specified and TLS is enabled it will fall back to standard LDAP bind address.
+    # Can be used when using tlsexclusive = false and need a seperate bind-address for TLS.
+    listen = "localhost:3894" 
+    cert = "certs/server.crt"
+    key = "certs/server.key"
 
 #################
 # The backend section controls the data store.


### PR DESCRIPTION
This commit expands on the settings available for using TLS. It puts TLS settings under the [frontend.tls] section and adds a new setting to [frontend] called TLSExclusive (bool).
TLSExclusive specifies whether or not to only run TLS when it is enabled, and is 'true' by default. Setting it to 'false' and having TLS enabled, causes the server to start both a LDAP and LDAPS server,
and therefore requires to seperate 'listen' options (to run on different ports) - the Frontend.Listen and the Frontend.TLS.Listen. If TLSExclusive is set to 'true' and no Frontend.TLS.Listen is specified, it will use the Frontend.Listen.

sample-simple.cfg is updated with example and comments