### PR TITLE
Allow hot-reloading config on change

### DIFF
--- a/glauth.go
+++ b/glauth.go
@@ -3,16 +3,17 @@ package main
 import (
 	"expvar"
 	"fmt"
-	"os"
-	"strings"
-
 	"github.com/BurntSushi/toml"
 	"github.com/GeertJohan/yubigo"
 	"github.com/docopt/docopt-go"
+	"github.com/fsnotify/fsnotify"
+	"github.com/jinzhu/copier"
 	"github.com/nmcclain/ldap"
 	"github.com/op/go-logging"
 	"gopkg.in/amz.v1/aws"
 	"gopkg.in/amz.v1/s3"
+	"os"
+	"strings"
 )
 
 // Set with buildtime vars
@@ -41,10 +42,19 @@ Options:
   --version                 Show version.
 `
 
-// exposed expvar variables
-var stats_frontend = expvar.NewMap("proxy_frontend")
-var stats_backend = expvar.NewMap("proxy_backend")
-var stats_general = expvar.NewMap("proxy")
+var (
+	log      *logging.Logger
+	args     map[string]interface{}
+	stderr   *logging.LogBackend
+	yubiAuth *yubigo.YubiAuth
+	// exposed expvar variables
+	// TODO: Should be renamed according to golang naming conventions for exported vars, StatsFrontend, StatsBackend, StatsGeneral
+	stats_frontend = expvar.NewMap("proxy_frontend")
+	stats_backend  = expvar.NewMap("proxy_backend")
+	stats_general  = expvar.NewMap("proxy")
+
+	activeConfig = &config{}
+)
 
 // interface for backend handler
 type Backend interface {
@@ -110,6 +120,7 @@ type config struct {
 	API                configAPI
 	Backend            configBackend
 	Debug              bool
+	WatchConfig        bool
 	YubikeyClientID    string
 	YubikeySecret      string
 	Frontend           configFrontend
@@ -123,8 +134,6 @@ type config struct {
 	AwsSecretAccessKey string
 	AwsRegion          string
 }
-
-var log = logging.MustGetLogger(programName)
 
 // Reads builtime vars and returns a full string containing info about
 // the currently running version of the software. Primarily used by the
@@ -169,70 +178,101 @@ func getVersionString() string {
 }
 
 func main() {
-	stderr := initLogging()
+	stderr = initLogging()
 	log.Debug("AP start")
 
-	cfg, err := doConfig()
-	if err != nil {
+	if err := parseArgs(); err != nil {
+		log.Fatalf("Could not parse command-line arguments", err.Error())
+	}
+	if err := doConfig(); err != nil {
 		log.Fatalf("Configuration file error: %s", err.Error())
 	}
-	if cfg.Syslog {
-		enableSyslog(stderr)
-	}
 
+	startService()
+}
+
+func startService() {
 	// stats
 	stats_general.Set("version", stringer(LastGitTag))
 
 	// web API
-	if cfg.API.Enabled {
+	if activeConfig.API.Enabled {
 		log.Debug("Web API enabled")
-		go RunAPI(cfg)
+		go RunAPI(activeConfig)
 	}
 
-	yubiAuth := (*yubigo.YubiAuth)(nil)
-
-	if len(cfg.YubikeyClientID) > 0 && len(cfg.YubikeySecret) > 0 {
-		yubiAuth, err = yubigo.NewYubiAuth(cfg.YubikeyClientID, cfg.YubikeySecret)
-
-		if err != nil {
-			log.Fatalf("Yubikey Auth failed")
-		}
-	}
+	startConfigWatcher()
 
 	// configure the backend
 	s := ldap.NewServer()
 	s.EnforceLDAP = true
 	var handler Backend
-	switch cfg.Backend.Datastore {
+	switch activeConfig.Backend.Datastore {
 	case "ldap":
-		handler = newLdapHandler(cfg)
+		handler = newLdapHandler(activeConfig)
 	case "config":
-		handler = newConfigHandler(cfg, yubiAuth)
+		handler = newConfigHandler(activeConfig, yubiAuth)
 	default:
-		log.Fatalf("Unsupported backend %s - must be 'config' or 'ldap'.", cfg.Backend.Datastore)
+		log.Fatalf("Unsupported backend %s - must be 'config' or 'ldap'.", activeConfig.Backend.Datastore)
 	}
-	log.Notice(fmt.Sprintf("Using %s backend", cfg.Backend.Datastore))
+	log.Notice(fmt.Sprintf("Using %s backend", activeConfig.Backend.Datastore))
 	s.BindFunc("", handler)
 	s.SearchFunc("", handler)
 	s.CloseFunc("", handler)
 
-	if cfg.LDAP.Enabled {
+	if activeConfig.LDAP.Enabled {
 		// Dont block if also starting a LDAPS server afterwards
-		shouldBlock := !cfg.LDAPS.Enabled
+		shouldBlock := !activeConfig.LDAPS.Enabled
 
 		if shouldBlock {
-			startLDAP(&cfg.LDAP, s)
+			startLDAP(&activeConfig.LDAP, s)
 		} else {
-			go startLDAP(&cfg.LDAP, s)
+			go startLDAP(&activeConfig.LDAP, s)
 		}
 	}
 
-	if cfg.LDAPS.Enabled {
+	if activeConfig.LDAPS.Enabled {
 		// Always block here
-		startLDAPS(&cfg.LDAPS, s)
+		startLDAPS(&activeConfig.LDAPS, s)
 	}
 
 	log.Critical("AP exit")
+}
+
+func startConfigWatcher() {
+	configFileLocation := getConfigLocation()
+
+	if strings.HasPrefix(configFileLocation, "s3://") {
+		return
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatalf("Could not start config-watcher: %s", err.Error())
+	}
+
+	go func() {
+		for {
+			select {
+			case event := <-watcher.Events:
+				if activeConfig.WatchConfig {
+					if event.Op.String() == "WRITE" {
+						if err := doConfig(); err != nil {
+							log.Warningf("Could not reload config: %sHolding on to old config", err.Error())
+						} else {
+							log.Notice("Config was reloaded")
+						}
+					}
+				}
+			case err := <-watcher.Errors:
+				if activeConfig.WatchConfig {
+					log.Info("Error!", err)
+				}
+			}
+		}
+	}()
+
+	watcher.Add(configFileLocation)
 }
 
 func startLDAP(ldapConfig *configLDAP, server *ldap.Server) {
@@ -249,21 +289,28 @@ func startLDAPS(ldapsConfig *configLDAPS, server *ldap.Server) {
 	}
 }
 
-// doConfig reads the cli flags and config file
-func doConfig() (*config, error) {
+func parseArgs() error {
+	var err error
+
+	if args, err = docopt.Parse(usage, nil, true, getVersionString(), false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getConfigLocation() string {
+	return args["--config"].(string)
+}
+
+func parseConfigFile(configFileLocation string) (*config, error) {
 	cfg := config{}
 	// setup defaults
 	cfg.LDAP.Enabled = false
 	cfg.LDAPS.Enabled = true
 
-	// parse the command-line args
-	args, err := docopt.Parse(usage, nil, true, getVersionString(), false)
-	if err != nil {
-		return &cfg, err
-	}
-
 	// parse the config file
-	if strings.HasPrefix(args["--config"].(string), "s3://") {
+	if strings.HasPrefix(configFileLocation, "s3://") {
 		if _, present := aws.Regions[args["-r"].(string)]; present == false {
 			return &cfg, fmt.Errorf("Invalid AWS region: %s", args["-r"])
 		}
@@ -279,7 +326,7 @@ func doConfig() (*config, error) {
 			}
 		}
 		// parse S3 url
-		s3url := strings.TrimPrefix(args["--config"].(string), "s3://")
+		s3url := strings.TrimPrefix(configFileLocation, "s3://")
 		parts := strings.SplitN(s3url, "/", 2)
 		if len(parts) != 2 {
 			return &cfg, fmt.Errorf("Invalid S3 URL: %s", s3url)
@@ -293,16 +340,15 @@ func doConfig() (*config, error) {
 			return &cfg, err
 		}
 	} else { // local config file
-		if _, err := toml.DecodeFile(args["--config"].(string), &cfg); err != nil {
+		if _, err := toml.DecodeFile(configFileLocation, &cfg); err != nil {
 			return &cfg, err
 		}
 	}
-	// enable features
-	if cfg.Debug {
-		logging.SetLevel(logging.DEBUG, programName)
-		log.Debug("Debugging enabled")
-	}
 
+	return &cfg, nil
+}
+
+func handleConfig(cfg config) (*config, error) {
 	if len(cfg.Frontend.Listen) > 0 && (len(cfg.LDAP.Listen) > 0 || len(cfg.LDAPS.Listen) > 0) {
 		// Both old server-config and new - dont allow
 		return &cfg, fmt.Errorf("Both old and new server-config in use - please remove old format ([frontend]) and migrate to new format ([ldap], [ldaps])")
@@ -357,15 +403,65 @@ func doConfig() (*config, error) {
 	case "config":
 	case "ldap":
 	default:
-		return &cfg, fmt.Errorf("Invalid backend %s - must be 'config' or 'ldap'.", cfg.Backend.Datastore)
+		return &cfg, fmt.Errorf("Invalid backend %s - must be 'config' or 'ldap'", cfg.Backend.Datastore)
 	}
 	return &cfg, nil
 }
 
+// doConfig reads the cli flags and config file
+func doConfig() error {
+	// Parse config-file into config{} struct
+	cfg, err := parseConfigFile(getConfigLocation())
+	if err != nil {
+		return err
+	}
+
+	// Handle validation and parsing of old [frontend] section into [ldap] and/or [ldaps] sections
+	cfg, err = handleConfig(*cfg)
+	if err != nil {
+		return err
+	}
+
+	// Before greenlighting new config entirely, lets make sure the yubiauth works - in case they changed
+	if activeConfig.YubikeyClientID != cfg.YubikeyClientID || activeConfig.YubikeySecret != cfg.YubikeySecret {
+		if len(cfg.YubikeyClientID) > 0 && len(cfg.YubikeySecret) > 0 {
+			_yubiAuth, err := yubigo.NewYubiAuth(cfg.YubikeyClientID, cfg.YubikeySecret)
+			if err != nil {
+				return err
+			}
+
+			// No errors, override
+			yubiAuth = _yubiAuth
+		}
+	}
+
+	// All config is validated and alright, copy to ativeConfig
+	if err := copier.Copy(activeConfig, cfg); err != nil {
+		return err
+	}
+
+	// Handle logging settings for new config
+	// - we do this last to make sure we only respect a fully validated config
+	stderr = initLogging()
+
+	if activeConfig.Debug {
+		logging.SetLevel(logging.DEBUG, programName)
+		log.Debug("Debugging enabled")
+	}
+	if activeConfig.Syslog {
+		enableSyslog(stderr)
+	}
+
+	return nil
+}
+
 // initLogging sets up logging to stderr
 func initLogging() *logging.LogBackend {
+	log = logging.MustGetLogger(programName)
+
 	format := "%{color}%{time:15:04:05.000000} %{shortfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}"
 	logBackend := logging.NewLogBackend(os.Stderr, "", 0)
+
 	logging.SetBackend(logBackend)
 	logging.SetLevel(logging.NOTICE, programName)
 	logging.SetFormatter(logging.MustStringFormatter(format))
@@ -380,6 +476,8 @@ func enableSyslog(stderrBackend *logging.LogBackend) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	logging.SetBackend(stderrBackend, syslogBackend)
+
 	log.Debug("Syslog enabled")
 }

--- a/sample-simple.cfg
+++ b/sample-simple.cfg
@@ -4,7 +4,11 @@
 #################
 # General configuration.
 debug = true
-#syslog = true
+# syslog = true
+#
+# Enable hot-reload of configuration on changes
+# - does NOT work [ldap], [ldaps], [backend] or [api] sections
+# watchconfig = true
 
 #################
 # yubikeyclientid = "yubi-api-clientid"


### PR DESCRIPTION
This change add the root-level option 'watchconfig'. 

Enabling this option will make GLAuth watch for writes to the config-file. When a write is detected it will parse and validate the config, and finally swap out the activeConfig (which is feeded by ref into LDAP handlers etc. on startup) with the new one.

To be able to do this, i had to move around and rewrite a lot of stuff related to loading the config, so i was able to parse the new config in isolation, and only swap out the activeConfig when validated.

We need this feature to be able to have zero down-time while adding/removing new users or groups, or changing the debug/syslog-flags while running. 

The options comes with some limitations, which are also stated in the example config: It will NOT be able to reload the [ldap], [ldaps], [backend] or [api] sections as they are used when booting up the server-instances, and would require downtime to reload. A restart will be required when changing those.