### PR TITLE
Add App Password Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ More configuration options are documented here: https://github.com/nmcclain/glau
    * Specify OTP secret used to validate OTP passcode
    * Example: 3hnvnk4ycv44glzigd6s25j4dougs3rk
    * default = blank
+ * passappsha256
+   * Specify an array of app passwords which can also succesfully bind - these bypass the OTP check. Hash the same way as password.
+   * Example: ["c32255dbf6fd6b64883ec8801f793bccfa2a860f2b1ae1315cd95cdac1338efa","4939efa7c87095dacb5e7e8b8cfb3a660fa1f5edcc9108f6d7ec20ea4d6b3a88"]
+   * default = blank
  * yubikey
    * Specify Yubikey ID for maching Yubikey OTP against the user
    * Example: cccjgjgkhcbb
@@ -156,6 +160,11 @@ When using 2FA, append the 2FA code to the end of the password when authenticati
 
 #### TOTP Configuration
 To enable TOTP authentication on a user, you can use a tool [like this](https://freeotp.github.io/qrcode.html) to generate a QR code (pick 'Timeout' and optionally let it generate a random secret for you), which can be scanned and used with the [Google Authenticator](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en) app. To enable TOTP authentication, configure the `otpsecret` for the user with the TOTP secret.
+
+#### App Passwords
+Additionally, you can specify an array of password hashes using the `passappsha256` for app passwords. These are not OTP validated, and are hashed in the same way as a password. This allows you to generate a long random string to be used in software which requires the ability to authenticate.
+
+However, app passwords can be used without OTP as well.
 
 #### Yubikey Configuration
 For Yubikey OTP token authentication, first [configure your Yubikey](https://www.yubico.com/products/services-software/personalization-tools/yubikey-otp/). After this, make sure to [request a `Client ID` and `Secret key` pair](https://upgrade.yubico.com/getapikey/).

--- a/configbackend.go
+++ b/configbackend.go
@@ -127,7 +127,7 @@ func (h configHandler) Bind(bindDN, bindSimplePw string, conn net.Conn) (resultC
 	for index, appPw := range user.PassAppSHA256 {
 
 		if appPw != hex.EncodeToString(hashFull.Sum(nil)) {
-			log.Debug(fmt.Sprintf("Attempted to bind app pw #%d - failure as %s from %s %s", index, bindDN, conn.RemoteAddr().String()))
+			log.Debug(fmt.Sprintf("Attempted to bind app pw #%d - failure as %s from %s", index, bindDN, conn.RemoteAddr().String()))
 		} else {
 			stats_frontend.Add("bind_successes", 1)
 			log.Debug("Bind success using app pw #%d as %s from %s", index, bindDN, conn.RemoteAddr().String())

--- a/configbackend.go
+++ b/configbackend.go
@@ -142,7 +142,7 @@ func (h configHandler) Bind(bindDN, bindSimplePw string, conn net.Conn) (resultC
 
 	// Then ensure the OTP is valid before checking
 	if !validotp {
-		log.Warning(fmt.Sprintf("Bind Error: invalid token as %s from %s", bindDN, conn.RemoteAddr().String()))
+		log.Warning(fmt.Sprintf("Bind Error: invalid OTP token as %s from %s", bindDN, conn.RemoteAddr().String()))
 		return ldap.LDAPResultInvalidCredentials, nil
 	}
 

--- a/configbackend.go
+++ b/configbackend.go
@@ -134,7 +134,7 @@ func (h configHandler) Bind(bindDN, bindSimplePw string, conn net.Conn) (resultC
 	for index, appPw := range user.PassAppSHA256 {
 
 		if appPw != hex.EncodeToString(hashFull.Sum(nil)) {
-			log.Info(fmt.Sprintf("Attempted to bind app pw #%d - failure as %s from %s", index, bindDN, conn.RemoteAddr().String()))
+			log.Debug(fmt.Sprintf("Attempted to bind app pw #%d - failure as %s from %s", index, bindDN, conn.RemoteAddr().String()))
 		} else {
 			stats_frontend.Add("bind_successes", 1)
 			log.Debug("Bind success using app pw #%d as %s from %s", index, bindDN, conn.RemoteAddr().String())

--- a/glauth.go
+++ b/glauth.go
@@ -86,20 +86,21 @@ type configAPI struct {
 	TLS         bool
 }
 type configUser struct {
-	Name         string
-	OtherGroups  []int
-	PassSHA256   string
-	PrimaryGroup int
-	SSHKeys      []string
-	OTPSecret    string
-	Yubikey      string
-	Disabled     bool
-	UnixID       int
-	Mail         string
-	LoginShell   string
-	GivenName    string
-	SN           string
-	Homedir      string
+	Name          string
+	OtherGroups   []int
+	PassSHA256    string
+	PassAppSHA256 []string
+	PrimaryGroup  int
+	SSHKeys       []string
+	OTPSecret     string
+	Yubikey       string
+	Disabled      bool
+	UnixID        int
+	Mail          string
+	LoginShell    string
+	GivenName     string
+	SN            string
+	Homedir       string
 }
 type configGroup struct {
 	Name          string

--- a/sample-simple.cfg
+++ b/sample-simple.cfg
@@ -61,6 +61,11 @@ debug = true
   passsha256 = "6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e3f416a" # dogood
   passappsha256 = ["6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e3f416a"]
   sshkeys = ["ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEA3UKCEllO2IZXgqNygiVb+dDLJJwVw3AJwV34t2jzR+/tUNVeJ9XddKpYQektNHsFmY93lJw5QDSbeH/mAC4KPoUM47EriINKEelRbyG4hC/ko/e2JWqEclPS9LP7GtqGmscXXo4JFkqnKw4TIRD52XI9n1syYM9Y8rJ88fjC/Lpn+01AB0paLVIfppJU35t0Ho9doHAEfEvcQA6tcm7FLJUvklAxc8WUbdziczbRV40KzDroIkXAZRjX7vXXhh/p7XBYnA0GO8oTa2VY4dTQSeDAUJSUxbzevbL0ll9Gi1uYaTDQyE5gbn2NfJSqq0OYA+3eyGtIVjFYZgi+txSuhw== rsa-key-20160209"]
+  passappsha256 = [
+    "c32255dbf6fd6b64883ec8801f793bccfa2a860f2b1ae1315cd95cdac1338efa", # TestAppPw1
+    "c9853d5f2599e90497e9f8cc671bd2022b0fb5d1bd7cfff92f079e8f8f02b8d3", # TestAppPw2
+    "4939efa7c87095dacb5e7e8b8cfb3a660fa1f5edcc9108f6d7ec20ea4d6b3a88", # TestAppPw3
+  ]
 
 [[users]]
   name = "serviceuser"

--- a/sample-simple.cfg
+++ b/sample-simple.cfg
@@ -59,6 +59,7 @@ debug = true
   loginShell = "/bin/sh"
   homeDir = "/root"
   passsha256 = "6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e3f416a" # dogood
+  passappsha256 = ["6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e3f416a"]
   sshkeys = ["ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEA3UKCEllO2IZXgqNygiVb+dDLJJwVw3AJwV34t2jzR+/tUNVeJ9XddKpYQektNHsFmY93lJw5QDSbeH/mAC4KPoUM47EriINKEelRbyG4hC/ko/e2JWqEclPS9LP7GtqGmscXXo4JFkqnKw4TIRD52XI9n1syYM9Y8rJ88fjC/Lpn+01AB0paLVIfppJU35t0Ho9doHAEfEvcQA6tcm7FLJUvklAxc8WUbdziczbRV40KzDroIkXAZRjX7vXXhh/p7XBYnA0GO8oTa2VY4dTQSeDAUJSUxbzevbL0ll9Gi1uYaTDQyE5gbn2NfJSqq0OYA+3eyGtIVjFYZgi+txSuhw== rsa-key-20160209"]
 
 [[users]]

--- a/scripts/travis/good-results/posixAccountList0
+++ b/scripts/travis/good-results/posixAccountList0
@@ -87,6 +87,27 @@ memberOf: cn=mailadmin,ou=groups,dc=glauth,dc=com
 memberOf: cn=superheros,ou=groups,dc=glauth,dc=com
 memberOf: cn=vpnaccess,ou=groups,dc=glauth,dc=com
 
+dn: cn=jackdoe,ou=superheros,dc=glauth,dc=com
+cn: jackdoe
+uid: jackdoe
+givenName: Jack
+sn: Doe
+ou: superheros
+uidNumber: 5005
+accountStatus: active
+mail: jdoe3@example.com
+objectClass: posixAccount
+loginShell: /bin/sh
+homeDirectory: /home/jackdoe
+description: jackdoe via LDAP
+gecos: jackdoe via LDAP
+gidNumber: 5501
+memberOf: cn=allaccs,ou=groups,dc=glauth,dc=com
+memberOf: cn=fulltime,ou=groups,dc=glauth,dc=com
+memberOf: cn=mailadmin,ou=groups,dc=glauth,dc=com
+memberOf: cn=superheros,ou=groups,dc=glauth,dc=com
+memberOf: cn=vpnaccess,ou=groups,dc=glauth,dc=com
+
 dn: cn=serviceuser,ou=svcaccts,dc=glauth,dc=com
 cn: serviceuser
 uid: serviceuser

--- a/scripts/travis/good-results/posixAccountList0
+++ b/scripts/travis/good-results/posixAccountList0
@@ -108,6 +108,27 @@ memberOf: cn=mailadmin,ou=groups,dc=glauth,dc=com
 memberOf: cn=superheros,ou=groups,dc=glauth,dc=com
 memberOf: cn=vpnaccess,ou=groups,dc=glauth,dc=com
 
+dn: cn=sarahdoe,ou=superheros,dc=glauth,dc=com
+cn: sarahdoe
+uid: sarahdoe
+givenName: Sarah
+sn: Doe
+ou: superheros
+uidNumber: 5006
+accountStatus: active
+mail: sdoe@example.com
+objectClass: posixAccount
+loginShell: /bin/sh
+homeDirectory: /home/sarahdoe
+description: sarahdoe via LDAP
+gecos: sarahdoe via LDAP
+gidNumber: 5501
+memberOf: cn=allaccs,ou=groups,dc=glauth,dc=com
+memberOf: cn=fulltime,ou=groups,dc=glauth,dc=com
+memberOf: cn=mailadmin,ou=groups,dc=glauth,dc=com
+memberOf: cn=superheros,ou=groups,dc=glauth,dc=com
+memberOf: cn=vpnaccess,ou=groups,dc=glauth,dc=com
+
 dn: cn=serviceuser,ou=svcaccts,dc=glauth,dc=com
 cn: serviceuser
 uid: serviceuser

--- a/scripts/travis/good-results/posixGroupList0
+++ b/scripts/travis/good-results/posixGroupList0
@@ -8,11 +8,13 @@ uniqueMember: cn=hackers,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jackdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jamesdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=johndoe,ou=superheros,dc=glauth,dc=com
+uniqueMember: cn=sarahdoe,ou=superheros,dc=glauth,dc=com
 memberUid: alexdoe
 memberUid: hackers
 memberUid: jackdoe
 memberUid: jamesdoe
 memberUid: johndoe
+memberUid: sarahdoe
 
 dn: cn=svcaccts,ou=groups,dc=glauth,dc=com
 cn: svcaccts
@@ -32,11 +34,13 @@ uniqueMember: cn=hackers,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jackdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jamesdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=johndoe,ou=superheros,dc=glauth,dc=com
+uniqueMember: cn=sarahdoe,ou=superheros,dc=glauth,dc=com
 memberUid: alexdoe
 memberUid: hackers
 memberUid: jackdoe
 memberUid: jamesdoe
 memberUid: johndoe
+memberUid: sarahdoe
 
 dn: cn=allaccs,ou=groups,dc=glauth,dc=com
 cn: allaccs
@@ -48,12 +52,14 @@ uniqueMember: cn=hackers,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jackdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jamesdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=johndoe,ou=superheros,dc=glauth,dc=com
+uniqueMember: cn=sarahdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=serviceuser,ou=svcaccts,dc=glauth,dc=com
 memberUid: alexdoe
 memberUid: hackers
 memberUid: jackdoe
 memberUid: jamesdoe
 memberUid: johndoe
+memberUid: sarahdoe
 memberUid: serviceuser
 
 dn: cn=mailadmin,ou=groups,dc=glauth,dc=com
@@ -64,9 +70,11 @@ objectClass: posixGroup
 uniqueMember: cn=alexdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jackdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jamesdoe,ou=superheros,dc=glauth,dc=com
+uniqueMember: cn=sarahdoe,ou=superheros,dc=glauth,dc=com
 memberUid: alexdoe
 memberUid: jackdoe
 memberUid: jamesdoe
+memberUid: sarahdoe
 
 dn: cn=webmail,ou=groups,dc=glauth,dc=com
 cn: webmail
@@ -82,7 +90,9 @@ objectClass: posixGroup
 uniqueMember: cn=alexdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jackdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jamesdoe,ou=superheros,dc=glauth,dc=com
+uniqueMember: cn=sarahdoe,ou=superheros,dc=glauth,dc=com
 memberUid: alexdoe
 memberUid: jackdoe
 memberUid: jamesdoe
+memberUid: sarahdoe
 

--- a/scripts/travis/good-results/posixGroupList0
+++ b/scripts/travis/good-results/posixGroupList0
@@ -5,10 +5,12 @@ gidNumber: 5501
 objectClass: posixGroup
 uniqueMember: cn=alexdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=hackers,ou=superheros,dc=glauth,dc=com
+uniqueMember: cn=jackdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jamesdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=johndoe,ou=superheros,dc=glauth,dc=com
 memberUid: alexdoe
 memberUid: hackers
+memberUid: jackdoe
 memberUid: jamesdoe
 memberUid: johndoe
 
@@ -27,10 +29,12 @@ gidNumber: 5503
 objectClass: posixGroup
 uniqueMember: cn=alexdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=hackers,ou=superheros,dc=glauth,dc=com
+uniqueMember: cn=jackdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jamesdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=johndoe,ou=superheros,dc=glauth,dc=com
 memberUid: alexdoe
 memberUid: hackers
+memberUid: jackdoe
 memberUid: jamesdoe
 memberUid: johndoe
 
@@ -41,11 +45,13 @@ gidNumber: 5504
 objectClass: posixGroup
 uniqueMember: cn=alexdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=hackers,ou=superheros,dc=glauth,dc=com
+uniqueMember: cn=jackdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jamesdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=johndoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=serviceuser,ou=svcaccts,dc=glauth,dc=com
 memberUid: alexdoe
 memberUid: hackers
+memberUid: jackdoe
 memberUid: jamesdoe
 memberUid: johndoe
 memberUid: serviceuser
@@ -56,8 +62,10 @@ description: mailadmin via LDAP
 gidNumber: 5505
 objectClass: posixGroup
 uniqueMember: cn=alexdoe,ou=superheros,dc=glauth,dc=com
+uniqueMember: cn=jackdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jamesdoe,ou=superheros,dc=glauth,dc=com
 memberUid: alexdoe
+memberUid: jackdoe
 memberUid: jamesdoe
 
 dn: cn=webmail,ou=groups,dc=glauth,dc=com
@@ -72,7 +80,9 @@ description: fulltime via LDAP
 gidNumber: 5507
 objectClass: posixGroup
 uniqueMember: cn=alexdoe,ou=superheros,dc=glauth,dc=com
+uniqueMember: cn=jackdoe,ou=superheros,dc=glauth,dc=com
 uniqueMember: cn=jamesdoe,ou=superheros,dc=glauth,dc=com
 memberUid: alexdoe
+memberUid: jackdoe
 memberUid: jamesdoe
 

--- a/scripts/travis/integration-test.sh
+++ b/scripts/travis/integration-test.sh
@@ -34,6 +34,9 @@ echo ""
 
 # Start in background, capture PID
 "$TRAVIS_BUILD_DIR/bin/glauth64" -c "$TRAVIS_BUILD_DIR/scripts/travis/test-config.cfg" &> /dev/null &
+
+# Use this instead to see glauth logs while running
+# "$TRAVIS_BUILD_DIR/bin/glauth64" -c "$TRAVIS_BUILD_DIR/scripts/travis/test-config.cfg" &
 glauthPid="$!"
 
 echo "Running glauth at PID=$glauthPid"
@@ -179,7 +182,6 @@ bindTest "cn=alexdoe,ou=superheros,dc=glauth,dc=com" \
   "cn=alexdoe" \
   "OtpAlexDoe"
 
-
 ## App Password Bind Test
 
 # Test the main pw
@@ -188,7 +190,7 @@ bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
   "cn=jackdoe" \
   "AppPwJackDoe0"
 
-# App passwords
+# App passwords on user
 bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
   "TestAppPw1" \
   "cn=jackdoe" \
@@ -203,7 +205,6 @@ bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
   "TestAppPw3" \
   "cn=jackdoe" \
   "AppPwJackDoe3"
-
 
 #############
 ## Cleanup

--- a/scripts/travis/integration-test.sh
+++ b/scripts/travis/integration-test.sh
@@ -180,6 +180,31 @@ bindTest "cn=alexdoe,ou=superheros,dc=glauth,dc=com" \
   "OtpAlexDoe"
 
 
+## App Password Bind Test
+
+# Test the main pw
+bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
+  "dogood1" \
+  "cn=jackdoe" \
+  "AppPwJackDoe0"
+
+# App passwords
+bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
+  "TestAppPw1" \
+  "cn=jackdoe" \
+  "AppPwJackDoe1"
+
+bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
+  "TestAppPw2" \
+  "cn=jackdoe" \
+  "AppPwJackDoe2"
+
+bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
+  "TestAppPw3" \
+  "cn=jackdoe" \
+  "AppPwJackDoe3"
+
+
 #############
 ## Cleanup
 #############

--- a/scripts/travis/integration-test.sh
+++ b/scripts/travis/integration-test.sh
@@ -72,9 +72,9 @@ function bindTest() {
   exitCode="$?"
 
   if [[ "$exitCode" = "0" ]] ; then
-    echo "  - PASS : 2FA test '$4'";
+    echo "  - PASS : Bind test '$4'";
   else
-    echo "  - FAIL : 2FA test '$4'";
+    echo "  - FAIL : Bind test '$4'";
     FAIL="1"
   fi
 

--- a/scripts/travis/integration-test.sh
+++ b/scripts/travis/integration-test.sh
@@ -206,6 +206,36 @@ bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
   "cn=jackdoe" \
   "AppPwJackDoe3"
 
+
+####
+# Test for a user who also uses OTP
+####
+otpCode="$(oathtool --totp -b -d 6 '3hnvnk4ycv44glzigd6s25j4dougs3rk')"
+
+pass="dogood1"
+
+# Test the main pw
+bindTest "cn=sarahdoe,ou=superheros,dc=glauth,dc=com" \
+  "$pass$OtpCode" \
+  "cn=jackdoe" \
+  "AppPwOtpDoe0"
+
+# App passwords on user
+bindTest "cn=sarahdoe,ou=superheros,dc=glauth,dc=com" \
+  "TestAppPw1" \
+  "cn=jackdoe" \
+  "AppPwOtpDoe1"
+
+bindTest "cn=sarahdoe,ou=superheros,dc=glauth,dc=com" \
+  "TestAppPw2" \
+  "cn=jackdoe" \
+  "AppPwOtpDoe2"
+
+bindTest "cn=sarahdoe,ou=superheros,dc=glauth,dc=com" \
+  "TestAppPw3" \
+  "cn=jackdoe" \
+  "AppPwOtpDoe3"
+
 #############
 ## Cleanup
 #############

--- a/scripts/travis/integration-test.sh
+++ b/scripts/travis/integration-test.sh
@@ -188,23 +188,23 @@ bindTest "cn=alexdoe,ou=superheros,dc=glauth,dc=com" \
 bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
   "dogood1" \
   "cn=jackdoe" \
-  "AppPwJackDoe0"
+  "AppPwNoOtp0"
 
 # App passwords on user
 bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
   "TestAppPw1" \
   "cn=jackdoe" \
-  "AppPwJackDoe1"
+  "AppPwNoOtp1"
 
 bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
   "TestAppPw2" \
   "cn=jackdoe" \
-  "AppPwJackDoe2"
+  "AppPwNoOtp2"
 
 bindTest "cn=jackdoe,ou=superheros,dc=glauth,dc=com" \
   "TestAppPw3" \
   "cn=jackdoe" \
-  "AppPwJackDoe3"
+  "AppPwNoOtp3"
 
 
 ####
@@ -216,25 +216,25 @@ pass="dogood1"
 
 # Test the main pw
 bindTest "cn=sarahdoe,ou=superheros,dc=glauth,dc=com" \
-  "$pass$OtpCode" \
-  "cn=jackdoe" \
-  "AppPwOtpDoe0"
+  "$pass$otpCode" \
+  "cn=sarahdoe" \
+  "AppPwOtp0"
 
 # App passwords on user
 bindTest "cn=sarahdoe,ou=superheros,dc=glauth,dc=com" \
   "TestAppPw1" \
-  "cn=jackdoe" \
-  "AppPwOtpDoe1"
+  "cn=sarahdoe" \
+  "AppPwOtp1"
 
 bindTest "cn=sarahdoe,ou=superheros,dc=glauth,dc=com" \
   "TestAppPw2" \
-  "cn=jackdoe" \
-  "AppPwOtpDoe2"
+  "cn=sarahdoe" \
+  "AppPwOtp2"
 
 bindTest "cn=sarahdoe,ou=superheros,dc=glauth,dc=com" \
   "TestAppPw3" \
-  "cn=jackdoe" \
-  "AppPwOtpDoe3"
+  "cn=sarahdoe" \
+  "AppPwOtp3"
 
 #############
 ## Cleanup

--- a/scripts/travis/test-config.cfg
+++ b/scripts/travis/test-config.cfg
@@ -74,7 +74,7 @@ debug = true
 
 
 
-# App PW test user
+# App PW test user without OTP
 [[users]]
   name = "jackdoe"
   givenname="Jack"
@@ -84,6 +84,24 @@ debug = true
   primarygroup = 5501
   loginShell = "/bin/sh"
   otherGroups = [5505,5507]
+  passsha256 = "ff522a502031e5f37054892d642c2c0f36af6c4e8f62225470d4a1a99f3c9c2a" #dogood1
+  passappsha256 = [
+    "c32255dbf6fd6b64883ec8801f793bccfa2a860f2b1ae1315cd95cdac1338efa", # TestAppPw1
+    "c9853d5f2599e90497e9f8cc671bd2022b0fb5d1bd7cfff92f079e8f8f02b8d3", # TestAppPw2
+    "4939efa7c87095dacb5e7e8b8cfb3a660fa1f5edcc9108f6d7ec20ea4d6b3a88", # TestAppPw3
+  ]
+
+# App PW test user with OTP
+[[users]]
+  name = "sarahdoe"
+  givenname="Sarah"
+  sn="Doe"
+  mail = "sdoe@example.com"
+  unixid = 5006
+  primarygroup = 5501
+  loginShell = "/bin/sh"
+  otherGroups = [5505,5507]
+  otpsecret = "3hnvnk4ycv44glzigd6s25j4dougs3rk"
   passsha256 = "ff522a502031e5f37054892d642c2c0f36af6c4e8f62225470d4a1a99f3c9c2a" #dogood1
   passappsha256 = [
     "c32255dbf6fd6b64883ec8801f793bccfa2a860f2b1ae1315cd95cdac1338efa", # TestAppPw1

--- a/scripts/travis/test-config.cfg
+++ b/scripts/travis/test-config.cfg
@@ -85,10 +85,10 @@ debug = true
   loginShell = "/bin/sh"
   otherGroups = [5505,5507]
   passsha256 = "ff522a502031e5f37054892d642c2c0f36af6c4e8f62225470d4a1a99f3c9c2a" #dogood1
-  passshaApp256 = [
-    "239769285512b19bb7ab80d2e03845eb26cc9d0212d239cf604efcb8b939acc5", # TestAppPw1
-    "e0d03e5e97cf16bf75d653724531065e62c8925e5f572df3329c64027f95a2a6", # TestAppPw2
-    "2fc63df04c96d7ec06204df80bdd4e6309e612b5e4ff72fb99ce1605c6f2947d" # TestAppPw3
+  passappsha256 = [
+    "c32255dbf6fd6b64883ec8801f793bccfa2a860f2b1ae1315cd95cdac1338efa", # TestAppPw1
+    "c9853d5f2599e90497e9f8cc671bd2022b0fb5d1bd7cfff92f079e8f8f02b8d3", # TestAppPw2
+    "4939efa7c87095dacb5e7e8b8cfb3a660fa1f5edcc9108f6d7ec20ea4d6b3a88", # TestAppPw3
   ]
 
 

--- a/scripts/travis/test-config.cfg
+++ b/scripts/travis/test-config.cfg
@@ -73,6 +73,25 @@ debug = true
   passsha256 = "b1cae08a1fd8b0bd0855e48f74ba2f8548904dd5de72311e6234617a3f661e16" # ThisAloneWontWork!
 
 
+
+# App PW test user
+[[users]]
+  name = "jackdoe"
+  givenname="Jack"
+  sn="Doe"
+  mail = "jdoe3@example.com"
+  unixid = 5005
+  primarygroup = 5501
+  loginShell = "/bin/sh"
+  otherGroups = [5505,5507]
+  passsha256 = "ff522a502031e5f37054892d642c2c0f36af6c4e8f62225470d4a1a99f3c9c2a" #dogood1
+  passshaApp256 = [
+    "239769285512b19bb7ab80d2e03845eb26cc9d0212d239cf604efcb8b939acc5", # TestAppPw1
+    "e0d03e5e97cf16bf75d653724531065e62c8925e5f572df3329c64027f95a2a6", # TestAppPw2
+    "2fc63df04c96d7ec06204df80bdd4e6309e612b5e4ff72fb99ce1605c6f2947d" # TestAppPw3
+  ]
+
+
 [[users]]
   name = "serviceuser"
   unixid = 5003


### PR DESCRIPTION
Implements #54.

As a related issue to implementing OTP support, the second half of that is app password support, for the end devices which don't require a shorter memorable password, but also can not add the changing OTP token to the end of every request.

This would allow the user to define an array of app passwords on a user record, which the user can use to alternatively authenticate.

TODO:

 - [x] Implement core feature
 - [x] Add test for non-otp user
 - [x] Add test for otp user
 - [x] Update readme
 - [x] Update sample config in repo root