### PR TITLE
More durable Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /app
 ENV GOPATH=/tmp/gocode
 ENV GOOS=linux
 ENV GOARCH=amd64
+ENV CGO_ENABLED=0
 
 # Only needed for alpine builds
 RUN apk add --no-cache git bzr make
@@ -32,7 +33,7 @@ RUN make linux64 && cp ./bin/glauth64 /app/glauth
 # Run Step
 #################
 
-FROM golang:alpine as run
+FROM alpine as run
 MAINTAINER Ben Yanke <ben@benyanke.com>
 
 # Copies a sample config to be used if a volume isn't mounted with user's config
@@ -46,14 +47,12 @@ COPY --from=build /app/scripts/docker/start.sh /app/docker/
 COPY --from=build /app/scripts/docker/default-config.cfg /app/docker/
 
 # Install ldapsearch for container health checks, then ensure ldapsearch is installed
-RUN apk update && apk add --no-cache openldap-clients && which ldapsearch && rm -rf /var/cache/apk/*
+RUN apk update && apk add --no-cache dumb-init openldap-clients && which ldapsearch && rm -rf /var/cache/apk/*
 
 # Install init
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 && chmod +x /usr/local/bin/dumb-init
 
 # Expose web and LDAP ports
 EXPOSE 389 636 5555
 
-ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/bin/sh", "/app/docker/start.sh"]
-


### PR DESCRIPTION
Hi,
I've noticed that you where using alpine specific golang image for the execution.
This has a a bigger footprint then the alpine standard alpine image.
To fix this I've added ` ENV CGO_ENABLED=0` make the executable portable.

Also I've changed how dumb-init is installed.
Dumb Init is now ufficially in the Alpine repository. 
This make the Dockerfile more portable and you won't need to change the version everytime.

Andrea