### PR TITLE
Use travis/dpv v1 body option for release message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ deploy:
   file: bin/*
   draft: true
   name: "DRAFT RELEASE: $TRAVIS_TAG"
-  release_notes: |
+  body: |
     # Commit Details
     $TRAVIS_COMMIT_MESSAGE
     


### PR DESCRIPTION
dpl v2 is not yet used in production for travis, so I ran into https://travis-ci.org/glauth/glauth/jobs/654427357#L556

v1 directly uses octokits parameters: https://github.com/octokit/octokit.rb/blob/master/lib/octokit/client/releases.rb#L35
