### PR TITLE
add support for writehandlers

### DIFF
--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -274,6 +274,21 @@ func (h configHandler) Search(bindDN string, searchReq ldap.SearchRequest, conn 
 	return ldap.ServerSearchResult{Entries: entries, Referrals: []string{}, Controls: []ldap.Control{}, ResultCode: ldap.LDAPResultSuccess}, nil
 }
 
+// Add is not supported for a static config file
+func (h configHandler) Add(boundDN string, req ldap.AddRequest, conn net.Conn) (result ldap.LDAPResultCode, err error) {
+	return ldap.LDAPResultInsufficientAccessRights, nil
+}
+
+// Modify is not supported for a static config file
+func (h configHandler) Modify(boundDN string, req ldap.ModifyRequest, conn net.Conn) (result ldap.LDAPResultCode, err error) {
+	return ldap.LDAPResultInsufficientAccessRights, nil
+}
+
+// Delete is not supported for a static config file
+func (h configHandler) Delete(boundDN string, deleteDN string, conn net.Conn) (result ldap.LDAPResultCode, err error) {
+	return ldap.LDAPResultInsufficientAccessRights, nil
+}
+
 // Close does not actually close anything, because the config data is kept in memory
 func (h configHandler) Close(boundDn string, conn net.Conn) error {
 	stats.Frontend.Add("closes", 1)

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -4,7 +4,13 @@ import "github.com/nmcclain/ldap"
 
 // Handler is the common interface for all datastores
 type Handler interface {
+	// read support
 	ldap.Binder
 	ldap.Searcher
 	ldap.Closer
+
+	// write support
+	ldap.Adder
+	ldap.Modifier // Note: modifying eg the uid or cn might change the dn because the hierarchy is determined by the backend
+	ldap.Deleter
 }

--- a/pkg/handler/ldap.go
+++ b/pkg/handler/ldap.go
@@ -140,6 +140,22 @@ func (h ldapHandler) Search(boundDN string, searchReq ldap.SearchRequest, conn n
 	h.log.V(6).Info("AP: Search OK", "filter", search.Filter, "numentries", len(ssr.Entries))
 	return ssr, nil
 }
+
+// Add is not yet supported for the ldap backend
+func (h ldapHandler) Add(boundDN string, req ldap.AddRequest, conn net.Conn) (result ldap.LDAPResultCode, err error) {
+	return ldap.LDAPResultInsufficientAccessRights, nil
+}
+
+// Modify is not yet supported for the ldap backend
+func (h ldapHandler) Modify(boundDN string, req ldap.ModifyRequest, conn net.Conn) (result ldap.LDAPResultCode, err error) {
+	return ldap.LDAPResultInsufficientAccessRights, nil
+}
+
+// Delete is not yet supported for the ldap backend
+func (h ldapHandler) Delete(boundDN string, deleteDN string, conn net.Conn) (result ldap.LDAPResultCode, err error) {
+	return ldap.LDAPResultInsufficientAccessRights, nil
+}
+
 func (h ldapHandler) Close(boundDn string, conn net.Conn) error {
 	conn.Close() // close connection to the server when then client is closed
 	h.lock.Lock()

--- a/pkg/handler/owncloud.go
+++ b/pkg/handler/owncloud.go
@@ -164,6 +164,21 @@ func (h ownCloudHandler) Search(bindDN string, searchReq ldap.SearchRequest, con
 	return ldap.ServerSearchResult{Entries: entries, Referrals: []string{}, Controls: []ldap.Control{}, ResultCode: ldap.LDAPResultSuccess}, nil
 }
 
+// Add is not yet supported for the owncloud backend
+func (h ownCloudHandler) Add(boundDN string, req ldap.AddRequest, conn net.Conn) (result ldap.LDAPResultCode, err error) {
+	return ldap.LDAPResultInsufficientAccessRights, nil
+}
+
+// Modify is not yet supported for the owncloud backend
+func (h ownCloudHandler) Modify(boundDN string, req ldap.ModifyRequest, conn net.Conn) (result ldap.LDAPResultCode, err error) {
+	return ldap.LDAPResultInsufficientAccessRights, nil
+}
+
+// Delete is not yet supported for the owncloud backend
+func (h ownCloudHandler) Delete(boundDN string, deleteDN string, conn net.Conn) (result ldap.LDAPResultCode, err error) {
+	return ldap.LDAPResultInsufficientAccessRights, nil
+}
+
 func (h ownCloudHandler) Close(boundDN string, conn net.Conn) error {
 	conn.Close() // close connection to the server when then client is closed
 	h.lock.Lock()


### PR DESCRIPTION
For now the backends will remain read only, but I want to work on a backend that uses [JSON user records](https://systemd.io/USER_RECORD/) and having write support would be awesome. This migh also be useful for other backends, eg the [database plugins](https://github.com/glauth/glauth/pull/133) @Fusion is working on.