### PR TITLE
Gitlab fix?

### DIFF
--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -183,7 +183,7 @@ func (h configHandler) Search(bindDN string, searchReq ldap.SearchRequest, conn 
 	if !strings.HasSuffix(bindDN, baseDN) {
 		return ldap.ServerSearchResult{ResultCode: ldap.LDAPResultInsufficientAccessRights}, fmt.Errorf("Search Error: BindDN %s not in our BaseDN %s", bindDN, h.cfg.Backend.BaseDN)
 	}
-	if !strings.HasSuffix(searchBaseDN, h.cfg.Backend.BaseDN) {
+	if searchBaseDN != "" && !strings.HasSuffix(searchBaseDN, h.cfg.Backend.BaseDN) {
 		return ldap.ServerSearchResult{ResultCode: ldap.LDAPResultInsufficientAccessRights}, fmt.Errorf("Search Error: search BaseDN %s is not in our BaseDN %s", searchBaseDN, h.cfg.Backend.BaseDN)
 	}
 	// return all users in the config file - the LDAP library will filter results for us


### PR DESCRIPTION
Hi,

Gitlab ldap auth is only working for me with this change, `gitlab-rake gitlab:ldap:check` test worked fine but login failed every time before.

After ldap-bind-success the next ldap-search filters for `(objectClass=*)` with empty search BaseDN, this produce the error:
`Search Error: search BaseDN is not in our BaseDN dc=glauth,dc=com`
Is a empty search BaseDN ok or is the ldap adapter from gitlab maybe RFC-ish broken?
The next search is working fine with search BaseDN and sub configured in the gitlab config.

Logs without change:
```
20:26:10.957456 doConfig ▶ DEBU 001  "level"=6 "msg"="Debugging enabled"  
20:26:10.957563 NewServer ▶ NOTI 002  "level"=3 "msg"="Using backend"  "datastore"="config"
20:26:10.957607 ListenAndServeTLS ▶ NOTI 003  "level"=3 "msg"="LDAPS server listening"  "address"="0.0.0.0:3894"
20:26:10.957744 ListenAndServe ▶ NOTI 004  "level"=3 "msg"="LDAP server listening"  "address"="0.0.0.0:3893"
20:27:48.905548 Bind ▶ DEBU 005  "level"=6 "msg"="Bind request"  "basedn"="dc=glauth,dc=com" "binddn"="cn=systemuser,ou=systemgroup,dc=glauth,dc=com" "src"={"IP":"127.0.0.1","Port":35684,"Zone":""}
20:27:48.905603 Bind ▶ DEBU 006  "level"=6 "msg"="Bind success"  "binddn"="cn=systemuser,ou=systemgroup,dc=glauth,dc=com" "src"={"IP":"127.0.0.1","Port":35684,"Zone":""}
20:27:48.906191 Search ▶ DEBU 007  "level"=6 "msg"="Search request"  "basedn"=",dc=glauth,dc=com" "binddn"="cn=systemuser,ou=systemgroup,dc=glauth,dc=com" "filter"="(objectClass=*)" "src"={"IP":"127.0.0.1","Port":35684,"Zone":""}
2020/08/18 20:27:48 handleSearchRequest error LDAP Result Code 50 "Insufficient Access Rights": Search Error: search BaseDN  is not in our BaseDN dc=glauth,dc=com
```
searchReq:
```
{
  "BaseDN": "",
  "Scope": 0,
  "DerefAliases": 0,
  "SizeLimit": 0,
  "TimeLimit": 0,
  "TypesOnly": false,
  "Filter": "(objectClass=*)",
  "Attributes": [
    "altServer",
    "namingContexts",
    "supportedCapabilities",
    "supportedControl",
    "supportedExtension",
    "supportedFeatures",
    "supportedLdapVersion",
    "supportedSASLMechanisms"
  ],
  "Controls": []
```



Logs with change:
```
20:18:37.678112 Bind ▶ DEBU 005  "level"=6 "msg"="Bind request"  "basedn"="dc=glauth,dc=com" "binddn"="cn=systemuser,ou=systemgroup,dc=glauth,dc=com" "src"={"IP":"127.0.0.1","Port":35498,"Zone":""}
20:18:37.678179 Bind ▶ DEBU 006  "level"=6 "msg"="Bind success"  "binddn"="cn=systemuser,ou=systemgroup,dc=glauth,dc=com" "src"={"IP":"127.0.0.1","Port":35498,"Zone":""}
20:18:37.678689 Search ▶ DEBU 007  "level"=6 "msg"="Search request"  "basedn"=",dc=glauth,dc=com" "binddn"="cn=systemuser,ou=systemgroup,dc=glauth,dc=com" "filter"="(objectClass=*)" "src"={"IP":"127.0.0.1","Port":35498,"Zone":""}
20:18:37.678748 Search ▶ DEBU 008  "level"=6 "msg"="AP: Search OK"  "filter"="(objectClass=*)"
20:18:37.679104 Search ▶ DEBU 009  "level"=6 "msg"="Search request"  "basedn"=",dc=glauth,dc=com" "binddn"="cn=systemuser,ou=systemgroup,dc=glauth,dc=com" "filter"="(\u0026(uid=gitlab.testuser)(objectClass=posixAccount)(ou=gitlabgroup))" "src"={"IP":"127.0.0.1","Port":35498,"Zone":""}
20:18:37.679169 Search ▶ DEBU 00a  "level"=6 "msg"="AP: Search OK"  "filter"="(\u0026(uid=gitlab.testuser)(objectClass=posixAccount)(ou=gitlabgroup))"
20:18:37.679840 Bind ▶ DEBU 00b  "level"=6 "msg"="Bind request"  "basedn"="dc=glauth,dc=com" "binddn"="cn=gitlab.testuser,ou=gitlabgroup,dc=glauth,dc=com" "src"={"IP":"127.0.0.1","Port":35498,"Zone":""}
20:18:37.679869 Bind ▶ DEBU 00c  "level"=6 "msg"="Bind success"  "binddn"="cn=gitlab.testuser,ou=gitlabgroup,dc=glauth,dc=com" "src"={"IP":"127.0.0.1","Port":35498,"Zone":""}
20:18:38.024933 Bind ▶ DEBU 00d  "level"=6 "msg"="Bind request"  "basedn"="dc=glauth,dc=com" "binddn"="cn=systemuser,ou=systemgroup,dc=glauth,dc=com" "src"={"IP":"127.0.0.1","Port":35500,"Zone":""}
20:18:38.024985 Bind ▶ DEBU 00e  "level"=6 "msg"="Bind success"  "binddn"="cn=systemuser,ou=systemgroup,dc=glauth,dc=com" "src"={"IP":"127.0.0.1","Port":35500,"Zone":""}
20:18:38.031440 Search ▶ DEBU 00f  "level"=6 "msg"="Search request"  "basedn"=",dc=glauth,dc=com" "binddn"="cn=systemuser,ou=systemgroup,dc=glauth,dc=com" "filter"="(objectClass=*)" "src"={"IP":"127.0.0.1","Port":35500,"Zone":""}
20:18:38.031509 Search ▶ DEBU 010  "level"=6 "msg"="AP: Search OK"  "filter"="(objectClass=*)"
20:18:38.031864 Search ▶ DEBU 011  "level"=6 "msg"="Search request"  "basedn"=",dc=glauth,dc=com" "binddn"="cn=systemuser,ou=systemgroup,dc=glauth,dc=com" "filter"="(\u0026(objectClass=posixAccount)(ou=gitlabgroup))" "src"={"IP":"127.0.0.1","Port":35500,"Zone":""}
20:18:38.031933 Search ▶ DEBU 012  "level"=6 "msg"="AP: Search OK"  "filter"="(\u0026(objectClass=posixAccount)(ou=gitlabgroup))"
```