### PR TITLE
check owncloud status code is ok

### DIFF
--- a/pkg/handler/owncloud.go
+++ b/pkg/handler/owncloud.go
@@ -193,7 +193,7 @@ func (h ownCloudHandler) login(name, pw string) bool {
 	req, _ := http.NewRequest("GET", h.meURL, nil)
 	req.SetBasicAuth(name, pw)
 	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
+	if err != nil || resp.StatusCode != http.StatusOK {
 		return false
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
owncloud sends a 303 when the user is not logged in, which does not produce an err. so we now check that the code is 200 to make sure the user is really authenticated.