### PR TITLE
Reuse http client as much as possible and allow insecure transport

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,7 @@ package config
 type Backend struct {
 	BaseDN      string
 	Datastore   string
-	Insecure    bool     // For LDAP backend only
+	Insecure    bool     // For LDAP and owncloud backend only
 	Servers     []string // For LDAP and owncloud backend only
 	NameFormat  string
 	GroupFormat string


### PR DESCRIPTION
This PR allows the owncloud handler to skip TLS certificate verification, reusing the already existing `Backend.Insecure` config option.