### PR TITLE
Allow using configmaps when deploying in kubernetes

### DIFF
--- a/glauth.go
+++ b/glauth.go
@@ -186,7 +186,13 @@ func startConfigWatcher() {
 			select {
 			case event := <-watcher.Events:
 				if activeConfig.WatchConfig {
-					if event.Op.String() == "WRITE" {
+					if event.Op&fsnotify.Remove == fsnotify.Remove {
+						// Ensure we still watch when symlinks are updated
+						watcher.Remove(event.Name)
+						watcher.Add(configFileLocation)
+					}
+
+					if event.Op.String() == "WRITE" || event.Op&fsnotify.Remove == fsnotify.Remove {
 						if err := doConfig(); err != nil {
 							log.V(2).Info("Could not reload config.Holding on to old config", "error", err.Error())
 						} else {

--- a/glauth.go
+++ b/glauth.go
@@ -192,7 +192,7 @@ func startConfigWatcher() {
 						watcher.Add(configFileLocation)
 					}
 
-					if event.Op.String() == "WRITE" || event.Op&fsnotify.Remove == fsnotify.Remove {
+					if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Remove == fsnotify.Remove {
 						if err := doConfig(); err != nil {
 							log.V(2).Info("Could not reload config.Holding on to old config", "error", err.Error())
 						} else {


### PR DESCRIPTION
Hi

The intent of this PR is to allow easier deployment using kubernetes. To me, a common way of doing this would be to configure glauth through a configmap or secret.

When running glauth in kubernetes, I discovered that glauth doesn't pickup changes made to a configmap. It seems that this is due to the fact that kubernetes symlinks the configmap-data into the right place - https://www.martensson.io/go-fsnotify-and-kubernetes-configmaps/

I made a small experiment and deployed to a local docker-desktop cluster and checked that when updating a configmap, an fsnotify watcher receives a chmod and remove event, hence this change reflects what I discovered.

I hope this PR aligns with the philosophy of glauth and that it is useful, I'm hoping to get some useful feedback from the CI system :-)

/Nicolai