### PR TITLE
Assets build fix.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,12 @@ ENV CGO_ENABLED=0
 # Only needed for alpine builds
 RUN apk add --no-cache git make go-bindata
 
-# Install deps
-RUN go get -d -v ./...
-
 # Run go-bindata to embed data for API
 RUN go-bindata -pkg=assets -o=pkg/assets/bindata.go assets
 RUN gofmt -w pkg/assets/bindata.go
+
+# Install deps
+RUN go get -d -v ./...
 
 # Build and copy final result
 RUN uname -a

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ fast: setup linux64 verify cleanup
 binaries: linux32 linux64 linuxarm32 linuxarm64 darwin64 win32 win64
 
 # Setup commands to always run
-setup: getdeps bindata format
+setup: bindata getdeps format
 
 #####################
 # Subcommands


### PR DESCRIPTION
Fresh repo with `go get -d -v ./...` running before assets bindata fail with:
```
github.com/glauth/glauth/pkg/frontend imports
	github.com/glauth/glauth/pkg/assets: cannot find module providing package github.com/glauth/glauth/pkg/assets
```
The change fixed this for me.