### PR TITLE
feat(ldaps): enable tlsconfig management.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/GeertJohan/yubigo v0.0.0-20190917122436-175bc097e60e h1:Bqtt5C+uVk+vH/t5dmB47uDCTwxw16EYHqvJnmY2aQc=
 github.com/GeertJohan/yubigo v0.0.0-20190917122436-175bc097e60e/go.mod h1:njRCDrl+1RQ/A/+KVU8Ho2EWAxUSkohOWczdW3dzDG0=
-github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1 h1:NDBbPmhS+EqABEs5Kg3n/5ZNjy73Pz7SIV+KCeqyXcs=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -41,7 +40,6 @@ github.com/yaegashi/msgraph.go v0.1.1-0.20200221123608-2d438cf2a7cc h1:ejaC8rvIv
 github.com/yaegashi/msgraph.go v0.1.1-0.20200221123608-2d438cf2a7cc/go.mod h1:tso14hwzqX4VbnWTNsxiL0DvMb2OwbGISFA7jDibdWc=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,11 +27,11 @@ type LDAPS struct {
 	Listen         string
 	Cert           string
 	Key            string
-	ServerName     string   `toml:"server_name"`
-	AllowedCACerts []string `toml:"allowed_cacerts"`
-	CipherSuites   []string `toml:"cipher_suites"`
-	MinVersion     string   `toml:"min_version"`
-	MaxVersion     string   `toml:"max_version"`
+	ServerName     string   `toml:"tls_server_name"`
+	AllowedCACerts []string `toml:"tls_allowed_cacerts"`
+	CipherSuites   []string `toml:"tls_cipher_suites"`
+	MinVersion     string   `toml:"tls_min_version"`
+	MaxVersion     string   `toml:"tls_max_version"`
 }
 type API struct {
 	Cert        string

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,10 +23,15 @@ type LDAP struct {
 	Listen  string
 }
 type LDAPS struct {
-	Enabled bool
-	Listen  string
-	Cert    string
-	Key     string
+	Enabled        bool
+	Listen         string
+	Cert           string
+	Key            string
+	ServerName     string   `toml:"server_name"`
+	AllowedCACerts []string `toml:"allowed_cacerts"`
+	CipherSuites   []string `toml:"cipher_suites"`
+	MinVersion     string   `toml:"min_version"`
+	MaxVersion     string   `toml:"max_version"`
 }
 type API struct {
 	Cert        string

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -54,6 +54,12 @@ func (c *LDAPS) TLSConfig() (*tls.Config, error) {
 
 	tlsConfig := &tls.Config{}
 
+	if c.ServerName != "" {
+		tlsConfig.ServerName = c.ServerName
+	} else {
+		tlsConfig.ServerName = "localhost"
+	}
+
 	if len(c.AllowedCACerts) != 0 {
 		pool, err := makeCertPool(c.AllowedCACerts)
 		if err != nil {

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+var tlsVersionMap = map[string]uint16{
+	"TLS10": tls.VersionTLS10,
+	"TLS11": tls.VersionTLS11,
+	"TLS12": tls.VersionTLS12,
+	"TLS13": tls.VersionTLS13,
+}
+
+var tlsCipherMap = map[string]uint16{
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":     tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+	"TLS_AES_128_GCM_SHA256":                  tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":                  tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256":            tls.TLS_CHACHA20_POLY1305_SHA256,
+}
+
+// -----------------------------------------------------------------------------
+
+// TLSConfig returns a tls.Config, may be nil without error if TLS is not
+// configured.
+func (c *LDAPS) TLSConfig() (*tls.Config, error) {
+	if c.Cert == "" && c.Key == "" && len(c.AllowedCACerts) == 0 {
+		return nil, nil
+	}
+
+	tlsConfig := &tls.Config{}
+
+	if len(c.AllowedCACerts) != 0 {
+		pool, err := makeCertPool(c.AllowedCACerts)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.ClientCAs = pool
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	if c.Cert != "" && c.Key != "" {
+		err := loadCertificate(tlsConfig, c.Cert, c.Key)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(c.CipherSuites) != 0 {
+		cipherSuites, err := parseCiphers(c.CipherSuites)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"could not parse server cipher suites %s: %v", strings.Join(c.CipherSuites, ","), err)
+		}
+		tlsConfig.CipherSuites = cipherSuites
+	}
+
+	if c.MaxVersion != "" {
+		version, err := parseTLSVersion(c.MaxVersion)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"could not parse tls max version %q: %v", c.MaxVersion, err)
+		}
+		tlsConfig.MaxVersion = version
+	}
+
+	if c.MinVersion != "" {
+		version, err := parseTLSVersion(c.MinVersion)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"could not parse tls min version %q: %v", c.MinVersion, err)
+		}
+		tlsConfig.MinVersion = version
+	}
+
+	if tlsConfig.MinVersion != 0 && tlsConfig.MaxVersion != 0 && tlsConfig.MinVersion > tlsConfig.MaxVersion {
+		return nil, fmt.Errorf(
+			"tls min version %q can't be greater than tls max version %q", tlsConfig.MinVersion, tlsConfig.MaxVersion)
+	}
+
+	return tlsConfig, nil
+}
+
+// -----------------------------------------------------------------------------
+
+func makeCertPool(certFiles []string) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	for _, certFile := range certFiles {
+		pem, err := ioutil.ReadFile(certFile)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"could not read certificate %q: %v", certFile, err)
+		}
+		ok := pool.AppendCertsFromPEM(pem)
+		if !ok {
+			return nil, fmt.Errorf(
+				"could not parse any PEM certificates %q: %v", certFile, err)
+		}
+	}
+
+	return pool, nil
+}
+
+func loadCertificate(config *tls.Config, certFile, keyFile string) error {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return fmt.Errorf(
+			"could not load keypair %s:%s: %v", certFile, keyFile, err)
+	}
+
+	config.Certificates = []tls.Certificate{cert}
+	config.BuildNameToCertificate()
+
+	return nil
+}
+
+func parseCiphers(ciphers []string) ([]uint16, error) {
+	suites := []uint16{}
+
+	for _, cipher := range ciphers {
+		if v, ok := tlsCipherMap[cipher]; ok {
+			suites = append(suites, v)
+		} else {
+			return nil, fmt.Errorf("unsupported cipher %q", cipher)
+		}
+	}
+
+	return suites, nil
+}
+
+func parseTLSVersion(version string) (uint16, error) {
+	if v, ok := tlsVersionMap[version]; ok {
+		return v, nil
+	}
+
+	return 0, fmt.Errorf("unsupported version %q", version)
+}

--- a/sample-tls12only.cfg
+++ b/sample-tls12only.cfg
@@ -1,0 +1,82 @@
+debug = true
+
+# This ([ldap] and [ldaps]) is the new server-config format
+[ldap]
+  enabled = true
+  listen = "0.0.0.0:3893"
+
+[ldaps]
+  enabled = true
+  listen = "0.0.0.0:6363"
+  cert = "certs/server.pem"
+  key = "certs/server-key.pem"
+  tls_server_name = "localhost"
+  tls_min_version = "TLS12"
+  tls_max_version = "TLS12"
+
+[backend]
+  datastore = "config"
+  baseDN = "dc=glauth,dc=com"
+
+[[users]]
+  name = "hackers"
+  unixid = 5001
+  primarygroup = 5501
+  passsha256 = "6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e3f416a" # dogood
+
+# This user record shows all of the possible fields available
+[[users]]
+  name = "johndoe"
+  givenname="John"
+  sn="Doe"
+  mail = "jdoe@example.com"
+  unixid = 5002
+  primarygroup = 5501
+  loginShell = "/bin/sh"
+  homeDir = "/root"
+  passsha256 = "6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e3f416a" # dogood
+  sshkeys = ["ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEA3UKCEllO2IZXgqNygiVb+dDLJJwVw3AJwV34t2jzR+/tUNVeJ9XddKpYQektNHsFmY93lJw5QDSbeH/mAC4KPoUM47EriINKEelRbyG4hC/ko/e2JWqEclPS9LP7GtqGmscXXo4JFkqnKw4TIRD52XI9n1syYM9Y8rJ88fjC/Lpn+01AB0paLVIfppJU35t0Ho9doHAEfEvcQA6tcm7FLJUvklAxc8WUbdziczbRV40KzDroIkXAZRjX7vXXhh/p7XBYnA0GO8oTa2VY4dTQSeDAUJSUxbzevbL0ll9Gi1uYaTDQyE5gbn2NfJSqq0OYA+3eyGtIVjFYZgi+txSuhw== rsa-key-20160209"]
+  passappsha256 = [
+    "c32255dbf6fd6b64883ec8801f793bccfa2a860f2b1ae1315cd95cdac1338efa", # TestAppPw1
+    "c9853d5f2599e90497e9f8cc671bd2022b0fb5d1bd7cfff92f079e8f8f02b8d3", # TestAppPw2
+    "4939efa7c87095dacb5e7e8b8cfb3a660fa1f5edcc9108f6d7ec20ea4d6b3a88", # TestAppPw3
+  ]
+
+[[users]]
+  name = "serviceuser"
+  unixid = 5003
+  primarygroup = 5502
+  passsha256 = "652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0" # mysecret
+
+# Test user showing 2 factor auth authentication
+[[users]]
+  name = "otpuser"
+  unixid = 5004
+  primarygroup = 5501
+  passsha256 = "652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0" # mysecret
+  otpsecret = "3hnvnk4ycv44glzigd6s25j4dougs3rk"
+  yubikey = "vvjrcfalhlaa"
+
+#################
+# The groups section contains a hardcoded list of valid users.
+[[groups]]
+  name = "superheros"
+  unixid = 5501
+
+[[groups]]
+  name = "svcaccts"
+  unixid = 5502
+
+[[groups]]
+  name = "vpn"
+  unixid = 5503
+  includegroups = [ 5501 ]
+
+#################
+# Enable and configure the optional REST API here.
+[api]
+  enabled = true
+  tls = false # enable TLS for production!!
+  listen = "0.0.0.0:5555"
+  cert = "cert.pem"
+  key = "key.pem"


### PR DESCRIPTION
# Context

Enable LDAPS TLSConfig setup from the config file in order to be restrictive and test various client setups.