### PR TITLE
the config struct is only needed by the config backend

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,7 +73,7 @@ type Group struct {
 }
 type Config struct {
 	API                API
-	Backend            Backend
+	Backend            Backend // Deprecated
 	Backends           []Backend
 	Helper             Helper
 	Debug              bool

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -39,7 +39,7 @@ func NewConfigHandler(opts ...Option) Handler {
 	handler := configHandler{
 		backend:     options.Backend,
 		log:         options.Logger,
-		cfg:         options.Config,
+		cfg:         options.Config, // TODO only used to access Users and Groups, move that to dedicated options
 		yubikeyAuth: options.YubiAuth,
 		attmatcher:  configattributematcher,
 	}

--- a/pkg/handler/ldap.go
+++ b/pkg/handler/ldap.go
@@ -29,7 +29,6 @@ type ldapHandler struct {
 	handlers HandlerWrapper
 	doPing   chan bool
 	log      logr.Logger
-	cfg      *config.Config
 	lock     *sync.Mutex // for sessions and servers
 	sessions map[string]ldapSession
 	servers  []ldapBackend
@@ -69,7 +68,6 @@ func NewLdapHandler(opts ...Option) Handler {
 		sessions: make(map[string]ldapSession),
 		doPing:   make(chan bool),
 		log:      options.Logger,
-		cfg:      options.Config,
 		helper:   options.Helper,
 		lock:     &ldaplock,
 		attm:     ldapattributematcher,

--- a/pkg/handler/owncloud.go
+++ b/pkg/handler/owncloud.go
@@ -30,7 +30,6 @@ type ownCloudSession struct {
 type ownCloudHandler struct {
 	backend  config.Backend
 	log      logr.Logger
-	cfg      *config.Config
 	client   *http.Client
 	sessions map[string]ownCloudSession
 	lock     *sync.Mutex
@@ -188,6 +187,7 @@ func (h ownCloudHandler) Delete(boundDN string, deleteDN string, conn net.Conn) 
 	return ldap.LDAPResultInsufficientAccessRights, nil
 }
 
+// FindUser with the given username. Called by the ldap backend to authenticate the bind. Optional
 func (h ownCloudHandler) FindUser(userName string) (found bool, user config.User, err error) {
 	return false, config.User{}, nil
 }
@@ -355,7 +355,6 @@ func NewOwnCloudHandler(opts ...Option) Handler {
 	return ownCloudHandler{
 		backend:  options.Backend,
 		log:      options.Logger,
-		cfg:      options.Config,
 		sessions: make(map[string]ownCloudSession),
 		lock:     &ownCloudLock,
 		client: &http.Client{

--- a/pkg/plugins/basesqlhandler.go
+++ b/pkg/plugins/basesqlhandler.go
@@ -39,7 +39,6 @@ type database struct {
 type databaseHandler struct {
 	backend     config.Backend
 	log         logr.Logger
-	cfg         *config.Config
 	yubikeyAuth *yubigo.YubiAuth
 	sqlBackend  SqlBackend
 	database    database
@@ -70,7 +69,6 @@ func NewDatabaseHandler(sqlBackend SqlBackend, opts ...handler.Option) handler.H
 	handler := databaseHandler{
 		backend:     options.Backend,
 		log:         options.Logger,
-		cfg:         options.Config,
 		yubikeyAuth: options.YubiAuth,
 		sqlBackend:  sqlBackend,
 		database:    dbInfo}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -89,20 +89,18 @@ func NewServer(opts ...Option) (*LdapSvc, error) {
 				handler.Backend(backend),
 				handler.Handlers(allHandlers),
 				handler.Logger(s.log),
-				handler.Config(s.c),
 				handler.Helper(helper),
 			)
 		case "owncloud":
 			h = handler.NewOwnCloudHandler(
 				handler.Backend(backend),
 				handler.Logger(s.log),
-				handler.Config(s.c),
 			)
 		case "config":
 			h = handler.NewConfigHandler(
 				handler.Backend(backend),
 				handler.Logger(s.log),
-				handler.Config(s.c),
+				handler.Config(s.c), // TODO only used to access Users and Groups, move that to dedicated options
 				handler.YubiAuth(s.yubiAuth),
 			)
 		case "plugin":
@@ -124,7 +122,6 @@ func NewServer(opts ...Option) (*LdapSvc, error) {
 			h = initFunc(
 				handler.Backend(backend),
 				handler.Logger(s.log),
-				handler.Config(s.c),
 				handler.YubiAuth(s.yubiAuth),
 			)
 		default:


### PR DESCRIPTION
The config struct is only used by the config backend for the users and groups. Let us drop the config from the handlers to provent confusion which backend to use: the `h.Backend` or the `h.cfg.Backend`