### PR TITLE
Feature/plugin interface

### DIFF
--- a/pkg/plugins/basesqlhandler.go
+++ b/pkg/plugins/basesqlhandler.go
@@ -37,6 +37,8 @@ type SqlBackend interface {
 	GetGroupMembersQuery() string
 	// Get group member IDs query
 	GetGroupMemberIDsQuery() string
+	// Get User Capabilities Query
+	GetUserCapabilitiesQuery() string
 }
 
 type database struct {
@@ -148,10 +150,7 @@ func (h databaseHandler) FindUser(userName string, searchByUPN bool) (f bool, u 
 
 		if !h.cfg.Behaviors.IgnoreCapabilities {
 			capability := config.Capability{}
-			rows, err := h.database.cnx.Query(fmt.Sprintf(`
-				SELECT c.action,c.object
-				FROM capabilities c WHERE userid=%s`,
-				h.sqlBackend.GetPrepareSymbol()), user.UIDNumber)
+			rows, err := h.database.cnx.Query(h.sqlBackend.GetUserCapabilitiesQuery(), user.UIDNumber)
 			if err == nil {
 				for rows.Next() {
 					err := rows.Scan(&capability.Action, &capability.Object)

--- a/pkg/plugins/mysql.go
+++ b/pkg/plugins/mysql.go
@@ -49,6 +49,10 @@ func (b MysqlBackend) GetGroupMemberIDsQuery() string {
 	return "SELECT name,uidnumber,primarygroup,passbcrypt,passsha256,otpsecret,yubikey,othergroups FROM users"
 }
 
+func (b MysqlBackend) GetUserCapabilitiesQuery() string {
+	return "SELECT action,object FROM capabilities WHERE userid=?"
+}
+
 // Create db/schema if necessary
 func (b MysqlBackend) CreateSchema(db *sql.DB) {
 	statement, _ := db.Prepare(`

--- a/pkg/plugins/mysql.go
+++ b/pkg/plugins/mysql.go
@@ -22,7 +22,7 @@ func (b MysqlBackend) GetDriverName() string {
 }
 
 func (b MysqlBackend) FindUserQuery(criterion string) string {
-	return fmt.Sprintf("SELECT uidnumber,primarygroup,passbcrypt,passsha256,otpsecret,yubikey FROM users WHERE %s=?", criterion)
+	return fmt.Sprintf("SELECT u.uidnumber,u.primarygroup,u.passbcrypt,u.passsha256,u.otpsecret,u.yubikey FROM users u WHERE %s=?", criterion)
 }
 
 func (b MysqlBackend) FindGroupQuery() string {

--- a/pkg/plugins/postgres.go
+++ b/pkg/plugins/postgres.go
@@ -22,7 +22,7 @@ func (b PostgresBackend) GetDriverName() string {
 }
 
 func (b PostgresBackend) FindUserQuery(criterion string) string {
-	return fmt.Sprintf("SELECT uidnumber,primarygroup,passbcrypt,passsha256,otpsecret,yubikey FROM users WHERE %s=$1", criterion)
+	return fmt.Sprintf("SELECT u.uidnumber,u.primarygroup,u.passbcrypt,u.passsha256,u.otpsecret,u.yubikey FROM users u WHERE %s=$1", criterion)
 }
 
 func (b PostgresBackend) FindGroupQuery() string {

--- a/pkg/plugins/postgres.go
+++ b/pkg/plugins/postgres.go
@@ -49,6 +49,10 @@ func (b PostgresBackend) GetGroupMemberIDsQuery() string {
 	return "SELECT name,uidnumber,primarygroup,passbcrypt,passsha256,otpsecret,yubikey,othergroups FROM users"
 }
 
+func (b PostgresBackend) GetUserCapabilitiesQuery() string {
+	return "SELECT action,object FROM capabilities WHERE userid=$1"
+}
+
 // Create db/schema if necessary
 func (b PostgresBackend) CreateSchema(db *sql.DB) {
 	statement, _ := db.Prepare(`

--- a/pkg/plugins/sqlite.go
+++ b/pkg/plugins/sqlite.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"fmt"
 
 	_ "github.com/mattn/go-sqlite3"
 
@@ -20,8 +21,32 @@ func (b SqliteBackend) GetDriverName() string {
 	return "sqlite3"
 }
 
-func (b SqliteBackend) GetPrepareSymbol() string {
-	return "?"
+func (b SqliteBackend) FindUserQuery(criterion string) string {
+	return fmt.Sprintf("SELECT uidnumber,primarygroup,passbcrypt,passsha256,otpsecret,yubikey FROM users WHERE %s=?", criterion)
+}
+
+func (b SqliteBackend) FindGroupQuery() string {
+	return "SELECT gidnumber FROM groups WHERE lower(name)=?"
+}
+
+func (b SqliteBackend) FindPosixAccountsQuery() string {
+	return "SELECT name,uidnumber,primarygroup,passbcrypt,passsha256,otpsecret,yubikey,othergroups,givenname,sn,mail,loginshell,homedirectory,disabled FROM users"
+}
+
+func (b SqliteBackend) MemoizeGroupsQuery() string {
+	return `
+		SELECT g1.name,g1.gidnumber,ig.includegroupid
+		FROM groups g1
+		LEFT JOIN includegroups ig ON g1.gidnumber=ig.parentgroupid
+		LEFT JOIN groups g2 ON ig.includegroupid=g2.gidnumber`
+}
+
+func (b SqliteBackend) GetGroupMembersQuery() string {
+	return "SELECT u.name,u.uidnumber,u.primarygroup,u.passbcrypt,u.passsha256,u.otpsecret,u.yubikey,u.othergroups FROM users u WHERE lower(u.name)=?"
+}
+
+func (b SqliteBackend) GetGroupMemberIDsQuery() string {
+	return "SELECT name,uidnumber,primarygroup,passbcrypt,passsha256,otpsecret,yubikey,othergroups FROM users"
 }
 
 // Create db/schema if necessary

--- a/pkg/plugins/sqlite.go
+++ b/pkg/plugins/sqlite.go
@@ -49,6 +49,10 @@ func (b SqliteBackend) GetGroupMemberIDsQuery() string {
 	return "SELECT name,uidnumber,primarygroup,passbcrypt,passsha256,otpsecret,yubikey,othergroups FROM users"
 }
 
+func (b SqliteBackend) GetUserCapabilitiesQuery() string {
+	return "SELECT action,object FROM capabilities WHERE userid=?"
+}
+
 // Create db/schema if necessary
 func (b SqliteBackend) CreateSchema(db *sql.DB) {
 	statement, _ := db.Prepare(`

--- a/pkg/plugins/sqlite.go
+++ b/pkg/plugins/sqlite.go
@@ -22,7 +22,7 @@ func (b SqliteBackend) GetDriverName() string {
 }
 
 func (b SqliteBackend) FindUserQuery(criterion string) string {
-	return fmt.Sprintf("SELECT uidnumber,primarygroup,passbcrypt,passsha256,otpsecret,yubikey FROM users WHERE %s=?", criterion)
+	return fmt.Sprintf("SELECT u.uidnumber,u.primarygroup,u.passbcrypt,u.passsha256,u.otpsecret,u.yubikey FROM users u WHERE %s=?", criterion)
 }
 
 func (b SqliteBackend) FindGroupQuery() string {


### PR DESCRIPTION
This feature moves sql queries from strings to interface methods so they can be customized per plugin. This way it is easier to separate sql logic from base sql, and write custom plugins.

The main use case is the ability to write a custom plugin that is independent of sql schemas and can be mapped to any existing user database  