### PR TITLE
Ci/fix build pipeline for v2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: set up multiarch builder
-        working-directory: ./v2
         run: |
           set -ex
           curl -sSL https://get.docker.com | bash
@@ -36,9 +35,7 @@ jobs:
       - name: log in github registry
         run: docker login --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" docker.pkg.github.com
       - name: build multiarch images
-        working-directory: ./v2
         run: docker buildx build -f Dockerfile-standalone -t docker.pkg.github.com/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):$(echo ${{ github.ref }} | tr / -) --platform linux/amd64,linux/arm64,linux/arm/v7 .
       - name: push multiarch images
-        working-directory: ./v2
         if: github.event.release.tag_name
         run: docker buildx build --push -f Dockerfile-standalone -t docker.pkg.github.com/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):${{ github.event.release.tag_name }} --platform linux/amd64,linux/arm64,linux/arm/v7 .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
       - name: log in github registry
         run: docker login --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" docker.pkg.github.com
       - name: build multiarch images
-        run: docker buildx build -f Dockerfile-standalone -t docker.pkg.github.com/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):$(echo ${{ github.ref }} | tr / -) --platform linux/amd64,linux/arm64,linux/arm/v7 .
+        run: docker buildx build -f v2/Dockerfile-standalone -t docker.pkg.github.com/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):$(echo ${{ github.ref }} | tr / -) --platform linux/amd64,linux/arm64,linux/arm/v7 .
       - name: push multiarch images
         if: github.event.release.tag_name
-        run: docker buildx build --push -f Dockerfile-standalone -t docker.pkg.github.com/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):${{ github.event.release.tag_name }} --platform linux/amd64,linux/arm64,linux/arm/v7 .
+        run: docker buildx build --push -f v2/Dockerfile-standalone -t docker.pkg.github.com/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):${{ github.event.release.tag_name }} --platform linux/amd64,linux/arm64,linux/arm/v7 .

--- a/v2/Dockerfile-plugins
+++ b/v2/Dockerfile-plugins
@@ -7,7 +7,7 @@ LABEL maintainers="Ben Yanke <ben@benyanke.com>, Jörn Friedrich Dreyer <jfd@but
 
 # Setup work env
 RUN mkdir /app /tmp/gocode
-ADD local/app /app/
+ADD . /app/
 WORKDIR /app/v2
 
 # Required envs for GO

--- a/v2/Dockerfile-standalone
+++ b/v2/Dockerfile-standalone
@@ -7,7 +7,7 @@ LABEL maintainers="Ben Yanke <ben@benyanke.com>, Jörn Friedrich Dreyer <jfd@but
 
 # Setup work env
 RUN mkdir /app /tmp/gocode
-ADD local/app /app/
+ADD . /app/
 WORKDIR /app/v2
 
 # Required envs for GO


### PR DESCRIPTION
Unfortunately, PR https://github.com/glauth/glauth/pull/245 seems to have broken the push of docker images for v2 -> https://github.com/glauth/glauth/actions/runs/1907893346. This PR tries to fix it and contains the following changes:

- Copy the working directory instead of the non-existent folder local/app
- Don't change working directory to v2 in Github actions
- Because of the change of the working directory, set the relative path (including v2) to the v2 Dockerfile when running `docker build`