### PR TITLE
Use NameFormat/GroupFormat when constructing RDN attributes [WIP]

### DIFF
--- a/v2/pkg/handler/config.go
+++ b/v2/pkg/handler/config.go
@@ -116,7 +116,7 @@ func (h configHandler) FindPosixAccounts(hierarchy string) (entrylist []*ldap.En
 
 	for _, u := range h.cfg.Users {
 		attrs := []*ldap.EntryAttribute{}
-		attrs = append(attrs, &ldap.EntryAttribute{Name: "cn", Values: []string{u.Name}})
+		attrs = append(attrs, &ldap.EntryAttribute{Name: h.backend.NameFormat, Values: []string{u.Name}})
 		attrs = append(attrs, &ldap.EntryAttribute{Name: "uid", Values: []string{u.Name}})
 
 		if len(u.GivenName) > 0 {
@@ -210,7 +210,7 @@ func (h configHandler) FindPosixGroups(hierarchy string) (entrylist []*ldap.Entr
 
 	for _, g := range h.cfg.Groups {
 		attrs := []*ldap.EntryAttribute{}
-		attrs = append(attrs, &ldap.EntryAttribute{Name: "cn", Values: []string{g.Name}})
+		attrs = append(attrs, &ldap.EntryAttribute{Name: h.backend.GroupFormat, Values: []string{g.Name}})
 		attrs = append(attrs, &ldap.EntryAttribute{Name: "uid", Values: []string{g.Name}})
 		attrs = append(attrs, &ldap.EntryAttribute{Name: "description", Values: []string{fmt.Sprintf("%s", g.Name)}})
 		attrs = append(attrs, &ldap.EntryAttribute{Name: "gidNumber", Values: []string{fmt.Sprintf("%d", g.GIDNumber)}})

--- a/v2/pkg/handler/owncloud.go
+++ b/v2/pkg/handler/owncloud.go
@@ -121,7 +121,7 @@ func (h ownCloudHandler) Search(bindDN string, searchReq ldap.SearchRequest, con
 		}
 		for _, g := range groups {
 			attrs := []*ldap.EntryAttribute{}
-			attrs = append(attrs, &ldap.EntryAttribute{Name: "cn", Values: []string{*g.ID}})
+			attrs = append(attrs, &ldap.EntryAttribute{Name: h.backend.GroupFormat, Values: []string{*g.ID}})
 			attrs = append(attrs, &ldap.EntryAttribute{Name: "description", Values: []string{fmt.Sprintf("%s from ownCloud", *g.ID)}})
 			//			attrs = append(attrs, &ldap.EntryAttribute{"gidNumber", []string{fmt.Sprintf("%d", g.GIDNumber)}})
 			attrs = append(attrs, &ldap.EntryAttribute{Name: "objectClass", Values: []string{"posixGroup"}})
@@ -151,7 +151,7 @@ func (h ownCloudHandler) Search(bindDN string, searchReq ldap.SearchRequest, con
 		}
 		for _, u := range users {
 			attrs := []*ldap.EntryAttribute{}
-			attrs = append(attrs, &ldap.EntryAttribute{Name: "cn", Values: []string{*u.ID}})
+			attrs = append(attrs, &ldap.EntryAttribute{Name: h.backend.NameFormat, Values: []string{*u.ID}})
 			attrs = append(attrs, &ldap.EntryAttribute{Name: "uid", Values: []string{*u.ID}})
 			if u.DisplayName != nil {
 				attrs = append(attrs, &ldap.EntryAttribute{Name: "givenName", Values: []string{*u.DisplayName}})

--- a/v2/pkg/plugins/basesqlhandler.go
+++ b/v2/pkg/plugins/basesqlhandler.go
@@ -510,7 +510,7 @@ func (h databaseHandler) getGroup(hierarchy string, g config.Group) *ldap.Entry 
 	asGroupOfUniqueNames := hierarchy == "ou=groups"
 
 	attrs := []*ldap.EntryAttribute{}
-	attrs = append(attrs, &ldap.EntryAttribute{"cn", []string{g.Name}})
+	attrs = append(attrs, &ldap.EntryAttribute{h.backend.GroupFormat, []string{g.Name}})
 	attrs = append(attrs, &ldap.EntryAttribute{"description", []string{fmt.Sprintf("%s via LDAP", g.Name)}})
 	attrs = append(attrs, &ldap.EntryAttribute{"gidNumber", []string{fmt.Sprintf("%d", g.GIDNumber)}})
 	attrs = append(attrs, &ldap.EntryAttribute{"uniqueMember", h.getGroupMemberDNs(g.GIDNumber)})
@@ -526,7 +526,7 @@ func (h databaseHandler) getGroup(hierarchy string, g config.Group) *ldap.Entry 
 
 func (h databaseHandler) getAccount(hierarchy string, u config.User) *ldap.Entry {
 	attrs := []*ldap.EntryAttribute{}
-	attrs = append(attrs, &ldap.EntryAttribute{"cn", []string{u.Name}})
+	attrs = append(attrs, &ldap.EntryAttribute{h.backend.NameFormat, []string{u.Name}})
 	attrs = append(attrs, &ldap.EntryAttribute{"uid", []string{u.Name}})
 
 	if len(u.GivenName) > 0 {

--- a/v2/scripts/ci/good-results/posixGroupList0
+++ b/v2/scripts/ci/good-results/posixGroupList0
@@ -1,5 +1,5 @@
 dn: ou=superheros,ou=users,dc=glauth,dc=com
-cn: superheros
+ou: superheros
 uid: superheros
 description: superheros
 gidNumber: 5501
@@ -19,7 +19,7 @@ objectClass: posixGroup
 objectClass: top
 
 dn: ou=svcaccts,ou=users,dc=glauth,dc=com
-cn: svcaccts
+ou: svcaccts
 uid: svcaccts
 description: svcaccts
 gidNumber: 5502
@@ -29,7 +29,7 @@ objectClass: posixGroup
 objectClass: top
 
 dn: ou=vpnaccess,ou=users,dc=glauth,dc=com
-cn: vpnaccess
+ou: vpnaccess
 uid: vpnaccess
 description: vpnaccess
 gidNumber: 5503
@@ -49,7 +49,7 @@ objectClass: posixGroup
 objectClass: top
 
 dn: ou=allaccs,ou=users,dc=glauth,dc=com
-cn: allaccs
+ou: allaccs
 uid: allaccs
 description: allaccs
 gidNumber: 5504
@@ -71,7 +71,7 @@ objectClass: posixGroup
 objectClass: top
 
 dn: ou=mailadmin,ou=users,dc=glauth,dc=com
-cn: mailadmin
+ou: mailadmin
 uid: mailadmin
 description: mailadmin
 gidNumber: 5505
@@ -87,7 +87,7 @@ objectClass: posixGroup
 objectClass: top
 
 dn: ou=webmail,ou=users,dc=glauth,dc=com
-cn: webmail
+ou: webmail
 uid: webmail
 description: webmail
 gidNumber: 5506
@@ -95,7 +95,7 @@ objectClass: posixGroup
 objectClass: top
 
 dn: ou=fulltime,ou=users,dc=glauth,dc=com
-cn: fulltime
+ou: fulltime
 uid: fulltime
 description: fulltime
 gidNumber: 5507


### PR DESCRIPTION
Before:

```
dn: ou=vpn,ou=users,dc=glauth,dc=com
cn: vpn
```

After:

```
dn: ou=vpn,ou=users,dc=glauth,dc=com
ou: vpn    <<< THIS HAS CHANGED
```

NOTE: whereas previously a search filter (cn=vpn) would have found the group, now you need (ou=vpn)

--------
I have marked this "[WIP]" because this is a change in visible behaviour, which I hope you'll agree is reasonable but it needs accepting.

I had originally included a change which I thought would be a bugfix for [v2/pkg/handler/owncloud.go](https://github.com/glauth/glauth/blob/v2.2.0-RC2/v2/pkg/handler/owncloud.go#L136) (although I don't use owncloud):

```
-                       dn := fmt.Sprintf("cn=%s,%s=groups,%s", *g.ID, h.backend.GroupFormat, h.backend.BaseDN)
+                       dn := fmt.Sprintf("%s=%s,ou=groups,%s", h.backend.GroupFormat, *g.ID, h.backend.BaseDN)
```

... however, this made it inconsistent with:

```
dn := fmt.Sprintf("%s=%s,%s=%s,%s", h.backend.NameFormat, *u.ID, h.backend.GroupFormat, "users", h.backend.BaseDN
```

I wanted to do

```
dn := fmt.Sprintf("%s=%s,%s=%s,ou=users,%s", h.backend.NameFormat, *u.ID, h.backend.GroupFormat, h.getGroupName(u.PrimaryGroup), h.backend.BaseDN)
```

but owncloud doesn't seem to have a concept of PrimaryGroup that I could use to build the DN in a consistent fashion with the rest of glauth. So I backed out this change.

There is a corresponding weird case in [v2/pkg/handler/ldapopshelper.go](https://github.com/glauth/glauth/blob/7da3859af0fda17c5ef85d0ec0178eeeb958d503/v2/pkg/handler/ldapopshelper.go#L617), but I'm not sure what's intended here so I haven't changed it:

```
                } else if len(parts) == 2 || (len(parts) == 3 && parts[2] == fmt.Sprintf("%s=users", h.GetBackend().GroupFormat)) {
                                                                                          ^^^^^^^^
```

Relates to #181