### PR TITLE
Rename the groups table to ldapgroups

### DIFF
--- a/v2/pkg/plugins/basesqlhandler.go
+++ b/v2/pkg/plugins/basesqlhandler.go
@@ -184,7 +184,7 @@ func (h databaseHandler) FindGroup(groupName string) (f bool, g config.Group, er
 	found := false
 
 	err = h.database.cnx.QueryRow(fmt.Sprintf(`
-			SELECT g.gidnumber FROM groups g WHERE lower(name)=%s`, h.sqlBackend.GetPrepareSymbol()), groupName).Scan(
+			SELECT g.gidnumber FROM ldapgroups g WHERE lower(name)=%s`, h.sqlBackend.GetPrepareSymbol()), groupName).Scan(
 		&group.GIDNumber)
 	if err == nil {
 		found = true
@@ -314,9 +314,9 @@ func (h databaseHandler) memoizeGroups() ([]config.Group, error) {
 	workMemGroups := make([]*config.Group, 0)
 	rows, err := h.database.cnx.Query(`
 		SELECT g1.name,g1.gidnumber,ig.includegroupid
-		FROM groups g1 
+		FROM ldapgroups g1
 		LEFT JOIN includegroups ig ON g1.gidnumber=ig.parentgroupid 
-		LEFT JOIN groups g2 ON ig.includegroupid=g2.gidnumber`)
+		LEFT JOIN ldapgroups g2 ON ig.includegroupid=g2.gidnumber`)
 	if err != nil {
 		return nil, errors.New("Unable to memoize groups list")
 	}


### PR DESCRIPTION
The groups table name is a reserved keyword in mysql and requires that the table name be escaped with backticks in order to use the groups name. Other databases such as postgres do not support the use of the backticks in the query statements. This change renames the groups table to ldapgroups in oder to avoid this problem altogether.

This does have a dependency on the backend sql plugins to alter the schema to match the new name.

Note: I have tested this with mysql, postgres and sqlite backends. Separate PRs will be opened for each of the plugin repositories to handle the migration of the table schema.
