### PR TITLE
Update the TRIM_FLAGS to use -trimpath

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -18,7 +18,7 @@ GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 # Build variables
 BUILD_VARS=-s -w -X main.GitCommit=${GIT_COMMIT} -X main.GitBranch=${GIT_BRANCH} -X main.BuildTime=${BUILD_TIME} -X main.GitClean=${GIT_CLEAN} -X main.LastGitTag=${LAST_GIT_TAG} -X main.GitTagIsCommit=${GIT_IS_TAG_COMMIT}
 BUILD_FILES=glauth.go
-TRIM_FLAGS=-gcflags "all=-trimpath=${PWD}" -asmflags "all=-trimpath=${PWD}"
+TRIM_FLAGS=-trimpath
 
 # Targets
 MAIN_TARGETS=linux/amd64,linux/386,linux/arm64,linux/arm-7,darwin/amd64,darwin/arm64,windows/amd64,windows/386


### PR DESCRIPTION
The current TRIM_FLAGS specify gcflags and asmflags directly in order to trim the path of the resulting binaries. This results in an error where the plugins cannot be loaded due to the error: "built with a different version of package". Per https://github.com/golang/go/issues/51955 in the golang repository, this is explicitly not supported. Switching to use the go build command's -trimpath flag resolves the issue.

Fixes #325

