### PR TITLE
Makefile: enable buildvcs and make vars changeable

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -24,6 +24,13 @@ TRIM_FLAGS>?=-trimpath
 MAIN_TARGETS=linux/amd64,linux/386,linux/arm64,linux/arm-7,darwin/amd64,darwin/arm64,windows/amd64,windows/386
 PLUGIN_TARGETS=linux/amd64,linux/386,linux/arm64,linux/arm-7,darwin/amd64,darwin/arm64
 
+
+
+# Build
+GOOS?=linux
+GOARCH?=amd64
+
+
 # Plugins
 -include pkg/plugins/*/Makefile
 
@@ -73,6 +80,20 @@ format:
 
 devrun:
 	go run ${BUILD_FILES} -c sample-simple.cfg
+
+mkbindir:
+	@echo "create directory bin/$(GOOS)$(GOARCH)"
+	@mkdir -p bin/$(GOOS)$(GOARCH)
+.PHONY: mkbindir
+
+build: mkbindir
+	@go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$(GOOS)$(GOARCH)/glauth -buildvcs .
+	$(MAKE) sha256
+.PHONY: build
+
+sha256:
+	@sha256sum bin/$(GOOS)$(GOARCH)/glauth > bin/$(GOOS)$(GOARCH)/glauth.sha256
+.PHONY: sha256
 
 linux386:
 	mkdir -p bin/$@ && GOOS=linux GOARCH=386 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$@/glauth ${BUILD_FILES} && cd bin/$@ && sha256sum glauth > glauth.sha256

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -16,9 +16,9 @@ GIT_IS_TAG_COMMIT=$(shell git describe --abbrev=0 --tags > /dev/null 2> /dev/nul
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 # Build variables
-BUILD_VARS=-s -w -X main.GitCommit=${GIT_COMMIT} -X main.GitBranch=${GIT_BRANCH} -X main.BuildTime=${BUILD_TIME} -X main.GitClean=${GIT_CLEAN} -X main.LastGitTag=${LAST_GIT_TAG} -X main.GitTagIsCommit=${GIT_IS_TAG_COMMIT}
+BUILD_VARS?=-s -w -X main.GitCommit=${GIT_COMMIT} -X main.GitBranch=${GIT_BRANCH} -X main.BuildTime=${BUILD_TIME} -X main.GitClean=${GIT_CLEAN} -X main.LastGitTag=${LAST_GIT_TAG} -X main.GitTagIsCommit=${GIT_IS_TAG_COMMIT}
 BUILD_FILES=glauth.go
-TRIM_FLAGS=-trimpath
+TRIM_FLAGS>?=-trimpath
 
 # Targets
 MAIN_TARGETS=linux/amd64,linux/386,linux/arm64,linux/arm-7,darwin/amd64,darwin/arm64,windows/amd64,windows/386

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -17,7 +17,7 @@ GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 # Build variables
 BUILD_VARS?=-s -w -X main.GitCommit=${GIT_COMMIT} -X main.GitBranch=${GIT_BRANCH} -X main.BuildTime=${BUILD_TIME} -X main.GitClean=${GIT_CLEAN} -X main.LastGitTag=${LAST_GIT_TAG} -X main.GitTagIsCommit=${GIT_IS_TAG_COMMIT}
-BUILD_FILES=glauth.go
+BUILD_FILES=.
 TRIM_FLAGS>?=-trimpath
 
 # Targets

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -96,28 +96,28 @@ sha256:
 .PHONY: sha256
 
 linux386:
-	mkdir -p bin/$@ && GOOS=linux GOARCH=386 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$@/glauth ${BUILD_FILES} && cd bin/$@ && sha256sum glauth > glauth.sha256
+	GOOS=linux GOARCH=386 $(MAKE) build
 
 linuxamd64:
-	mkdir -p bin/$@ && GOOS=linux GOARCH=amd64 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$@/glauth ${BUILD_FILES} && cd bin/$@ && sha256sum glauth > glauth.sha256
+	GOOS=linux GOARCH=amd64 $(MAKE) build
 
 linuxarm:
-	mkdir -p bin/$@ && GOOS=linux GOARCH=arm go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$@/glauth ${BUILD_FILES} && cd bin/$@ && sha256sum glauth > glauth.sha256
+	GOOS=linux GOARCH=arm $(MAKE) build
 
 linuxarm64:
-	mkdir -p bin/$@ && GOOS=linux GOARCH=arm64 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$@/glauth ${BUILD_FILES} && cd bin/$@ && sha256sum glauth > glauth.sha256
+	GOOS=linux GOARCH=arm64 $(MAKE) build
 
 darwinamd64:
-	mkdir -p bin/$@ && GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$@/glauth ${BUILD_FILES} && cd bin/$@ && sha256sum glauth > glauth.sha256
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 $(MAKE) build
 
 darwinarm64:
-	mkdir -p bin/$@ && GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$@/glauth ${BUILD_FILES} && cd bin/$@ && sha256sum glauth > glauth.sha256
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 $(MAKE) build
 
 win386:
-	mkdir -p bin/$@ && GOOS=windows GOARCH=386 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$@/glauth ${BUILD_FILES} && cd bin/$@ && sha256sum glauth > glauth.sha256
+	GOOS=windows GOARCH=386 $(MAKE) build
 
 winamd64:
-	mkdir -p bin/$@ && GOOS=windows GOARCH=amd64 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$@/glauth ${BUILD_FILES} && cd bin/$@ && sha256sum glauth > glauth.sha256
+	GOOS=windows GOARCH=amd64 $(MAKE) build
 
 verify:
 	@for binary in linux386 linuxamd64 linuxarm linuxarm64 darwinamd64 darwinarm64 win386 winamd64; do cd bin/$$binary && sha256sum glauth.sha256 -c && cd ../..; done


### PR DESCRIPTION
- build: make build vars optional and passable via env
- build: use . for BUILD_FILES var to allow buildvcs flag
- build: create mkbindir, build and sha256 targets
- build: reuse build target for each platform specific compilation
