### PR TITLE
version and build info: use release-please + runtime/debug

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,3 +23,5 @@ jobs:
           default-branch: master
           pull-request-title-pattern: "ci: release ${version}"
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          extra-files: |
+            v2/internal/version/const.go

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,4 +21,5 @@ jobs:
           package-name: GLAuth
           path: v2
           default-branch: dev
+          pull-request-title-pattern: "ci: release ${version}"
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,6 @@ jobs:
           release-type: go
           package-name: GLAuth
           path: v2
-          default-branch: dev
+          default-branch: master
           pull-request-title-pattern: "ci: release ${version}"
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -16,7 +16,7 @@ GIT_IS_TAG_COMMIT=$(shell git describe --abbrev=0 --tags > /dev/null 2> /dev/nul
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 # Build variables
-BUILD_VARS?=-s -w -X main.GitCommit=${GIT_COMMIT} -X main.GitBranch=${GIT_BRANCH} -X main.BuildTime=${BUILD_TIME} -X main.GitClean=${GIT_CLEAN} -X main.LastGitTag=${LAST_GIT_TAG} -X main.GitTagIsCommit=${GIT_IS_TAG_COMMIT}
+BUILD_VARS?=-s -w
 BUILD_FILES=.
 TRIM_FLAGS>?=-trimpath
 
@@ -87,7 +87,7 @@ mkbindir:
 .PHONY: mkbindir
 
 build: mkbindir
-	@go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$(GOOS)$(GOARCH)/glauth -buildvcs .
+	@go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$(GOOS)$(GOARCH)/glauth -buildvcs=false .
 	$(MAKE) sha256
 .PHONY: build
 

--- a/v2/glauth.go
+++ b/v2/glauth.go
@@ -7,6 +7,7 @@ import (
 	"github.com/arl/statsviz"
 	docopt "github.com/docopt/docopt-go"
 	"github.com/fsnotify/fsnotify"
+	"github.com/glauth/glauth/v2/internal/version"
 	"github.com/glauth/glauth/v2/pkg/config"
 	"github.com/glauth/glauth/v2/pkg/frontend"
 	"github.com/glauth/glauth/v2/pkg/logging"
@@ -24,14 +25,6 @@ import (
 	"strings"
 	"time"
 )
-
-// Set with buildtime vars
-var LastGitTag string
-var BuildTime string
-var GitCommit string
-var GitClean string
-var GitBranch string
-var GitTagIsCommit string
 
 const programName = "glauth"
 
@@ -64,48 +57,6 @@ var (
 
 	activeConfig = &config.Config{}
 )
-
-// Reads builtime vars and returns a full string containing info about
-// the currently running version of the software. Primarily used by the
-// --version flag at runtime.
-func getVersionString() string {
-
-	var versionstr string
-
-	versionstr = "GLauth"
-
-	// Notate the git context of the build
-	switch {
-	// If a release, use the tag
-	case GitClean == "1" && GitTagIsCommit == "1":
-		versionstr += " " + LastGitTag + "\n\n"
-
-	// If this branch had a tag before, mention the branch and the tag to give a rough idea of the base version
-	case len(GitBranch) > 1 && len(LastGitTag) > 1:
-		versionstr += "\nNon-release build from branch " + GitBranch + ", based on tag " + LastGitTag + "\n\n"
-
-	// If no previous tag specified, just mention the branch
-	case len(GitBranch) > 1:
-		versionstr += "\nNon-release build from branch " + GitBranch + "\n\n"
-
-	// Fallback message, if all else fails
-	default:
-		versionstr += "\nNon-release build\n\n"
-	}
-
-	// Include build time
-	if len(BuildTime) > 1 {
-		versionstr += "Build time: " + BuildTime + "\n"
-	}
-
-	// Add commit hash
-	if GitClean == "1" && len(GitCommit) > 1 {
-		versionstr += "Commit: " + GitCommit + "\n"
-	}
-
-	return versionstr
-
-}
 
 func main() {
 	if err := parseArgs(); err != nil {
@@ -250,7 +201,7 @@ func startConfigWatcher() {
 func parseArgs() error {
 	var err error
 
-	if args, err = docopt.Parse(usage, nil, true, getVersionString(), false); err != nil {
+	if args, err = docopt.Parse(usage, nil, true, version.GetVersion(), false); err != nil {
 		return err
 	}
 

--- a/v2/glauth.go
+++ b/v2/glauth.go
@@ -135,7 +135,7 @@ func main() {
 
 func startService() {
 	// stats
-	stats.General.Set("version", stats.Stringer(LastGitTag))
+	stats.General.Set("version", stats.Stringer(version.Version))
 
 	// web API
 	if activeConfig.API.Enabled {

--- a/v2/internal/version/const.go
+++ b/v2/internal/version/const.go
@@ -1,0 +1,5 @@
+package version
+
+// Version is the tag of the latest release, it gets changed by the ci
+// process when a release is happening
+const Version = "v2.3.0" // x-release-please-version

--- a/v2/internal/version/vcs.go
+++ b/v2/internal/version/vcs.go
@@ -1,0 +1,68 @@
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+type gitInfo struct {
+	BuildTime string
+	Commit    string
+	Dirty     bool
+}
+
+// GetVersion reads builtime vars and returns a full string containing info about
+// the currently running version of the software. Primarily used by the
+// --version flag at runtime.
+func GetVersion() string {
+
+	// TODO @shipperizer see if it's worth replacing with info.Main.Path
+	// aka github.com/glauth/glauth/v2 - not great but worth checking
+
+	name := "GLauth"
+
+	info, ok := debug.ReadBuildInfo()
+
+	if !ok {
+		return fmt.Sprintf(`
+%s
+Non-release build`,
+			name)
+	}
+
+	gitInfo := vcsInfo(info.Settings)
+
+	// If a release, use the tag
+	if !gitInfo.Dirty {
+		return fmt.Sprintf(`%s %s
+Build time: %s
+Commit: %s`, name, Version, gitInfo.BuildTime, gitInfo.Commit)
+	}
+
+	return fmt.Sprintf(`%s
+Non-release build based on tag %s
+Build time: %s
+Commit: %s`, name, Version, gitInfo.BuildTime, gitInfo.Commit)
+
+}
+
+func vcsInfo(settings []debug.BuildSetting) *gitInfo {
+	info := new(gitInfo)
+
+	info.BuildTime = "unknown"
+	info.Commit = "unknown"
+	info.Dirty = false
+
+	for _, v := range settings {
+		switch v.Key {
+		case "vcs.revision":
+			info.Commit = v.Value
+		case "vcs.modified":
+			info.Dirty = v.Value == "true"
+		case "vcs.time":
+			info.BuildTime = v.Value
+		}
+	}
+
+	return info
+}


### PR DESCRIPTION
- ci: change pr name pattern for release please
- ci: switch to use master as default branch and plan to drop dev
- fix: exploit release-please for tagging in code
- fix: use runtime/debug to fetch git build info
- fix: use newer function to fetch git info for version
- build: drop build tags


## Description

This PR tries to simplify the passing of build tags by exploiting the `x-release-please-version` annotation fot the git tag/version and the package `runtime/debug` for the extra information needed to be displayed in the version command/flag

tradeoff here is that from the `runtime/debug` package we can only tell what is the commit, build time and if the repo ahs uncommitted changes at the time of the build

thereof only 3 cases are possible:

* clean branch (any branch):
```
shipperizer in ~/shipperizer/glauth/v2 on versioning/git λ git status 
On branch versioning/git
Your branch is up to date with 'shipperizer/versioning/git'.

nothing to commit, working tree clean
shipperizer in ~/shipperizer/glauth/v2 on versioning/git ● λ make fast                                                                                                                      
go get -d ./...
go fmt
GOOS=linux GOARCH=amd64 make build
...
shipperizer in ~/shipperizer/glauth/v2 on versioning/git λ go version -m bin/linuxamd64/glauth
bin/linuxamd64/glauth: go1.20.3
	path	github.com/glauth/glauth/v2
...
	build	vcs=git
	build	vcs.revision=edae351537d5520dfc721c50d29fa820d55dfad0
	build	vcs.time=2023-10-03T20:45:35Z
	build	vcs.modified=false
shipperizer in ~/shipperizer/glauth/v2 on versioning/git λ bin/linuxamd64/glauth --version    
GLauth v2.3.0
Build time: 2023-10-03T20:45:35Z
Commit: edae351537d5520dfc721c50d29fa820d55dfad0
```

* uncommitted changes in a branch (any branch):
```
shipperizer in ~/shipperizer/glauth/v2 on versioning/git λ git status                                                                                                                     
On branch versioning/git
Your branch is up to date with 'shipperizer/versioning/git'.

Changes not staged for commit:
	modified:   sample-ldap.cfg

no changes added to commit
shipperizer in ~/shipperizer/glauth/v2 on versioning/git ● λ make fast                                                                                                                      
go get -d ./...
go fmt
GOOS=linux GOARCH=amd64 make build
...
shipperizer in ~/shipperizer/glauth/v2 on versioning/git ● λ go version -m bin/linuxamd64/glauth                                                                                            
bin/linuxamd64/glauth: go1.20.3
	path	github.com/glauth/glauth/v2
	mod	github.com/glauth/glauth/v2	(devel)	
...
	build	vcs=git
	build	vcs.revision=edae351537d5520dfc721c50d29fa820d55dfad0
	build	vcs.time=2023-10-03T20:45:35Z
	build	vcs.modified=true
shipperizer in ~/shipperizer/glauth/v2 on versioning/git ● λ bin/linuxamd64/glauth --version                                                                                  
GLauth
Non-release build based on tag v2.3.0
Build time: 2023-10-03T20:45:35Z
Commit: edae351537d5520dfc721c50d29fa820d55dfad0
```

* `-buildvcs` is not enabled at build time
```
shipperizer in ~/shipperizer/glauth/v2 on versioning/git ● λ go version -m bin/linuxamd64/glauth                                                                                            
bin/linuxamd64/glauth: go1.20.3
	path	github.com/glauth/glauth/v2
	mod	github.com/glauth/glauth/v2	(devel)	
...
	build	-ldflags="-s -w"
	build	CGO_ENABLED=1
	build	CGO_CFLAGS=
	build	CGO_CPPFLAGS=
	build	CGO_CXXFLAGS=
	build	CGO_LDFLAGS=
	build	GOARCH=amd64
	build	GOOS=linux
	build	GOAMD64=v1
shipperizer in ~/shipperizer/glauth/v2 on versioning/git λ bin/linuxamd64/glauth --version    
GLauth v2.3.0
Build time: unknown
Commit: unknown
```
