### PR TITLE
graceful shutdown

### DIFF
--- a/v2/glauth.go
+++ b/v2/glauth.go
@@ -202,7 +202,7 @@ func startService() {
 	// <-ctx.Done() if your application should wait for other services
 	// to finalize based on context cancellation.
 	log.Info().Msg("AP exit")
-	os.Exit(1)
+	os.Exit(0)
 }
 
 func startConfigWatcher() {

--- a/v2/glauth.go
+++ b/v2/glauth.go
@@ -167,30 +167,21 @@ func startService() {
 	}
 
 	if activeConfig.LDAP.Enabled {
-		// Don't block if also starting a LDAPS server afterwards
-		shouldBlock := !activeConfig.LDAPS.Enabled
-
-		if shouldBlock {
+		go func() {
 			if err := s.ListenAndServe(); err != nil {
 				log.Error().Err(err).Msg("could not start LDAP server")
 				os.Exit(1)
 			}
-		} else {
-			go func() {
-				if err := s.ListenAndServe(); err != nil {
-					log.Error().Err(err).Msg("could not start LDAP server")
-					os.Exit(1)
-				}
-			}()
-		}
+		}()
 	}
 
 	if activeConfig.LDAPS.Enabled {
-		// Always block here
-		if err := s.ListenAndServeTLS(); err != nil {
-			log.Error().Err(err).Msg("could not start LDAPS server")
-			os.Exit(1)
-		}
+		go func() {
+			if err := s.ListenAndServeTLS(); err != nil {
+				log.Error().Err(err).Msg("could not start LDAPS server")
+				os.Exit(1)
+			}
+		}()
 	}
 
 	log.Info().Msg("AP exit")


### PR DESCRIPTION
- fix: start servers on separate goroutines
- fix: listen to signals for graceful shutdowns
- fix: exit with 0 in case of programmed termination
