### PR TITLE
build: enable buildvcs

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -106,7 +106,7 @@ mkbindir:
 .PHONY: mkbindir
 
 build: mkbindir
-	@go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$(GOOS)$(GOARCH)/glauth -buildvcs=false .
+	@go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/$(GOOS)$(GOARCH)/glauth -buildvcs .
 	$(MAKE) sha256
 .PHONY: build
 


### PR DESCRIPTION
addresses and closes #388

```
shipperizer in ~/shipperizer/glauth/v2 on buildvcs ● ● λ make build                          
create directory bin/linuxamd64
make sha256
shipperizer in ~/shipperizer/glauth/v2 on buildvcs ● ● λ file bin/linuxamd64/glauth 
bin/linuxamd64/glauth: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=f5a386a9b401ab88d0bbe557e05b78ef7e68de4b, for GNU/Linux 3.2.0, stripped
shipperizer in ~/shipperizer/glauth/v2 on buildvcs ● ● λ go version -m  bin/linuxamd64/glauth
bin/linuxamd64/glauth: go1.21.1
	path	github.com/glauth/glauth/v2
	mod	github.com/glauth/glauth/v2	(devel)	
	dep	github.com/BurntSushi/toml	v1.3.2	h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
	dep	github.com/GeertJohan/yubigo	v0.0.0-20190917122436-175bc097e60e	h1:Bqtt5C+uVk+vH/t5dmB47uDCTwxw16EYHqvJnmY2aQc=
	dep	github.com/arl/statsviz	v0.6.0	h1:jbW1QJkEYQkufd//4NDYRSNBpwJNrdzPahF7ZmoGdyE=
	dep	github.com/beorn7/perks	v1.0.1	h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
	dep	github.com/boombuler/barcode	v1.0.1-0.20190219062509-6c824513bacc	h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
	dep	github.com/cenkalti/backoff/v4	v4.2.1	h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
	dep	github.com/cespare/xxhash/v2	v2.2.0	h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
	dep	github.com/docopt/docopt-go	v0.0.0-20180111231733-ee0de3bc6815	h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
	dep	github.com/fsnotify/fsnotify	v1.7.0	h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
	dep	github.com/glauth/ldap	v0.0.0-20231210225823-b9bf4d1baf6e	h1:ohe1O2DUo198delHsQvA8O+CgAPP8wv1SmSxLPlO9ao=
	dep	github.com/go-asn1-ber/asn1-ber	v1.5.4	h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
	dep	github.com/go-logr/logr	v1.3.0	h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
	dep	github.com/go-logr/stdr	v1.2.2	h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
	dep	github.com/golang/protobuf	v1.5.3	h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
	dep	github.com/gorilla/websocket	v1.5.0	h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
	dep	github.com/grpc-ecosystem/grpc-gateway/v2	v2.16.0	h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
	dep	github.com/jinzhu/copier	v0.4.0	h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
	dep	github.com/mattn/go-colorable	v0.1.13	h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
	dep	github.com/mattn/go-isatty	v0.0.19	h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
	dep	github.com/matttproud/golang_protobuf_extensions/v2	v2.0.0	h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
	dep	github.com/nmcclain/asn1-ber	v0.0.0-20170104154839-2661553a0484	h1:D9EvfGQvlkKaDr2CRKN++7HbSXbefUNDrPq60T+g24s=
	dep	github.com/nmcclain/ldap	v0.0.0-20210720162743-7f8d1e44eeba	h1:DO8NFYdcRv1dnyAINJIBm6Bw2XibtLvQniNFGzf2W8E=
	dep	github.com/pquerna/otp	v1.4.0	h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
	dep	github.com/prometheus/client_golang	v1.18.0	h1:HzFfmkOzH5Q8L8G+kSJKUx5dtG87sewO+FoDDqP5Tbk=
	dep	github.com/prometheus/client_model	v0.5.0	h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=
	dep	github.com/prometheus/common	v0.45.0	h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lneoxM=
	dep	github.com/prometheus/procfs	v0.12.0	h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
	dep	github.com/rickb777/date	v1.12.4	h1:+6IzcCCS/1t17DrmnEvrznyq7nM8vPwir6/UhlyohKw=
	dep	github.com/rickb777/plural	v1.2.0	h1:5tvEc7UBCZ7l8h/2UeybSkt/uu1DQsZFOFdNevmUhlE=
	dep	github.com/rs/zerolog	v1.31.0	h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
	dep	github.com/yaegashi/msgraph.go	v0.1.4	h1:leDXSczAbwBpYFSmmZrdByTiPoUw8dbTfNMetAjJvbw=
	dep	go.opentelemetry.io/contrib/propagators/jaeger	v1.21.1	h1:f4beMGDKiVzg9IcX7/VuWVy+oGdjx3dNJ72YehmtY5k=
	dep	go.opentelemetry.io/otel	v1.21.0	h1:hzLeKBZEL7Okw2mGzZ0cc4k/A7Fta0uoPgaJCr8fsFc=
	dep	go.opentelemetry.io/otel/exporters/otlp/otlptrace	v1.21.0	h1:cl5P5/GIfFh4t6xyruOgJP5QiA1pw4fYYdv6nc6CBWw=
	dep	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc	v1.21.0	h1:tIqheXEFWAZ7O8A7m+J0aPTmpJN3YQ7qetUAdkkkKpk=
	dep	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp	v1.21.0	h1:digkEZCJWobwBqMwC0cwCq8/wkkRy/OowZg5OArWZrM=
	dep	go.opentelemetry.io/otel/exporters/stdout/stdouttrace	v1.21.0	h1:VhlEQAPp9R1ktYfrPk5SOryw1e9LDDTZCbIPFrho0ec=
	dep	go.opentelemetry.io/otel/metric	v1.21.0	h1:tlYWfeo+Bocx5kLEloTjbcDwBuELRrIFxwdQ36PlJu4=
	dep	go.opentelemetry.io/otel/sdk	v1.21.0	h1:FTt8qirL1EysG6sTQRZ5TokkU8d0ugCj8htOgThZXQ8=
	dep	go.opentelemetry.io/otel/trace	v1.21.0	h1:WD9i5gzvoUPuXIXH24ZNBudiarZDKuekPqi/E8fpfLc=
	dep	go.opentelemetry.io/proto/otlp	v1.0.0	h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
	dep	go.uber.org/mock	v0.4.0	h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
	dep	golang.org/x/crypto	v0.18.0	h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc=
	dep	golang.org/x/net	v0.17.0	h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
	dep	golang.org/x/sys	v0.16.0	h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
	dep	golang.org/x/text	v0.14.0	h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
	dep	google.golang.org/genproto/googleapis/api	v0.0.0-20230822172742-b8732ec3820d	h1:DoPTO70H+bcDXcd39vOqb2viZxgqeBeSGtZ55yZU4/Q=
	dep	google.golang.org/genproto/googleapis/rpc	v0.0.0-20230822172742-b8732ec3820d	h1:uvYuEyMHKNt+lT4K3bN6fGswmK8qSvcreM3BwjDh+y4=
	dep	google.golang.org/grpc	v1.59.0	h1:Z5Iec2pjwb+LEOqzpB2MR12/eKFhDPhuqW91O+4bwUk=
	dep	google.golang.org/protobuf	v1.31.0	h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
	dep	gopkg.in/amz.v3	v3.0.0-20201001071545-24fc1eceb27b	h1:tdSyAzD5FHJmZAZ13d5WexAo7YJkiyGphhzFfInMnDw=
	build	-buildmode=exe
	build	-compiler=gc
	build	-ldflags="-s -w"
	build	CGO_ENABLED=1
	build	CGO_CFLAGS=
	build	CGO_CPPFLAGS=
	build	CGO_CXXFLAGS=
	build	CGO_LDFLAGS=
	build	GOARCH=amd64
	build	GOOS=linux
	build	GOAMD64=v1
	build	vcs=git
	build	vcs.revision=bc29d321bfacce8535ca7e2ee15e5c3ba1e17773
	build	vcs.time=2024-01-20T19:55:11Z
	build	vcs.modified=true
```