### PR TITLE
fix: patch group name fetches for the rest of handlers

### DIFF
--- a/v2/pkg/handler/owncloud.go
+++ b/v2/pkg/handler/owncloud.go
@@ -167,7 +167,9 @@ func (h ownCloudHandler) Search(bindDN string, searchReq ldap.SearchRequest, con
 		}
 		for _, g := range groups {
 			attrs := []*ldap.EntryAttribute{}
-			attrs = append(attrs, &ldap.EntryAttribute{Name: h.backend.GroupFormatAsArray[0], Values: []string{*g.ID}})
+			for _, groupAttr := range h.backend.GroupFormatAsArray {
+				attrs = append(attrs, &ldap.EntryAttribute{Name: groupAttr, Values: []string{*g.ID}})
+			}
 			attrs = append(attrs, &ldap.EntryAttribute{Name: "description", Values: []string{fmt.Sprintf("%s from ownCloud", *g.ID)}})
 			//			attrs = append(attrs, &ldap.EntryAttribute{"gidNumber", []string{fmt.Sprintf("%d", g.GIDNumber)}})
 			attrs = append(attrs, &ldap.EntryAttribute{Name: "objectClass", Values: []string{"posixGroup"}})

--- a/v2/pkg/plugins/basesqlhandler.go
+++ b/v2/pkg/plugins/basesqlhandler.go
@@ -609,7 +609,9 @@ func (h databaseHandler) getGroup(ctx context.Context, hierarchy string, g confi
 	asGroupOfUniqueNames := hierarchy == "ou=groups"
 
 	attrs := []*ldap.EntryAttribute{}
-	attrs = append(attrs, &ldap.EntryAttribute{Name: h.backend.GroupFormatAsArray[0], Values: []string{g.Name}})
+	for _, groupAttr := range h.backend.GroupFormatAsArray {
+		attrs = append(attrs, &ldap.EntryAttribute{Name: groupAttr, Values: []string{g.Name}})
+	}
 	attrs = append(attrs, &ldap.EntryAttribute{Name: "description", Values: []string{fmt.Sprintf("%s via LDAP", g.Name)}})
 	attrs = append(attrs, &ldap.EntryAttribute{Name: "gidNumber", Values: []string{fmt.Sprintf("%d", g.GIDNumber)}})
 	attrs = append(attrs, &ldap.EntryAttribute{Name: "uniqueMember", Values: h.getGroupMemberDNs(ctx, g.GIDNumber)})

--- a/v2/scripts/ci/good-results/posixGroupList0
+++ b/v2/scripts/ci/good-results/posixGroupList0
@@ -1,6 +1,6 @@
 dn: ou=superheros,ou=users,dc=glauth,dc=com
 ou: superheros
-uid: superheros
+cn: superheros
 description: superheros
 gidNumber: 5501
 uniqueMember: cn=alexdoe,ou=superheros,ou=users,dc=glauth,dc=com
@@ -20,7 +20,7 @@ objectClass: top
 
 dn: ou=svcaccts,ou=users,dc=glauth,dc=com
 ou: svcaccts
-uid: svcaccts
+cn: svcaccts
 description: svcaccts
 gidNumber: 5502
 uniqueMember: cn=serviceuser,ou=svcaccts,ou=users,dc=glauth,dc=com
@@ -30,7 +30,7 @@ objectClass: top
 
 dn: ou=vpnaccess,ou=users,dc=glauth,dc=com
 ou: vpnaccess
-uid: vpnaccess
+cn: vpnaccess
 description: vpnaccess
 gidNumber: 5503
 uniqueMember: cn=alexdoe,ou=superheros,ou=users,dc=glauth,dc=com
@@ -50,7 +50,7 @@ objectClass: top
 
 dn: ou=allaccs,ou=users,dc=glauth,dc=com
 ou: allaccs
-uid: allaccs
+cn: allaccs
 description: allaccs
 gidNumber: 5504
 uniqueMember: cn=alexdoe,ou=superheros,ou=users,dc=glauth,dc=com
@@ -72,7 +72,7 @@ objectClass: top
 
 dn: ou=mailadmin,ou=users,dc=glauth,dc=com
 ou: mailadmin
-uid: mailadmin
+cn: mailadmin
 description: mailadmin
 gidNumber: 5505
 uniqueMember: cn=alexdoe,ou=superheros,ou=users,dc=glauth,dc=com
@@ -88,7 +88,7 @@ objectClass: top
 
 dn: ou=webmail,ou=users,dc=glauth,dc=com
 ou: webmail
-uid: webmail
+cn: webmail
 description: webmail
 gidNumber: 5506
 objectClass: posixGroup
@@ -96,7 +96,7 @@ objectClass: top
 
 dn: ou=fulltime,ou=users,dc=glauth,dc=com
 ou: fulltime
-uid: fulltime
+cn: fulltime
 description: fulltime
 gidNumber: 5507
 uniqueMember: cn=alexdoe,ou=superheros,ou=users,dc=glauth,dc=com


### PR DESCRIPTION
c0ed90822fd4d2ee7104a1979d423a0c93d758ac fixed an issue with group names in the config backend, where groups didn't have their `cn` attribute assigned when returning LDAP results. However, this was not correctly applied to the rest of the backends, so this PR takes care of that.
