### PR TITLE
fix: Credentials leaked on INFO log level

### DIFF
--- a/v2/pkg/plugins/basesqlhandler.go
+++ b/v2/pkg/plugins/basesqlhandler.go
@@ -99,7 +99,7 @@ func NewDatabaseHandler(sqlBackend SqlBackend, opts ...handler.Option) handler.H
 	sqlBackend.CreateSchema(db)
 	sqlBackend.MigrateSchema(db, ColumnExists)
 
-	options.Logger.Info().Msg("Database (" + sqlBackend.GetDriverName() + "::" + options.Backend.Database + ") Plugin: Ready")
+	options.Logger.Debug().Msg("Database (" + sqlBackend.GetDriverName() + "::" + options.Backend.Database + ") Plugin: Ready")
 
 	return handler
 }

--- a/v2/pkg/server/server.go
+++ b/v2/pkg/server/server.go
@@ -98,7 +98,7 @@ func NewServer(opts ...Option) (*LdapSvc, error) {
 
 	if tlsConfig := options.TLSConfig; tlsConfig != nil {
 		s.l.TLSConfig = tlsConfig
-		s.log.Info().Interface("tls.certificates", tlsConfig.Certificates).Msg("enabling LDAP over TLS")
+		s.log.Debug().Interface("tls.certificates", tlsConfig.Certificates).Msg("enabling LDAP over TLS")
 	}
 
 	for i, backend := range s.c.Backends {


### PR DESCRIPTION
The server is leaking the DB credentials if you're using a SQL backend, and it is leaking the private key at log level INFO, which is the default logging level.

Lowering the loglevel to debug ensures that this appears only during debugging.
It could even be lowered to trace eventually.

Fixes: #452 