### PR TITLE
feat: starttls and ldaps now matching features

### DIFF
--- a/v2/go.sum
+++ b/v2/go.sum
@@ -14,6 +14,7 @@ github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -48,13 +48,18 @@ type (
 		TLSKey      string
 		TLSCertPath string
 		TLSKeyPath  string
+		LegacyTLS   bool
 	}
 
 	LDAPS struct {
 		Enabled bool
 		Listen  string
-		Cert    string
-		Key     string
+		// LDAPS TLS parameters
+		Cert      string
+		Key       string
+		CertPath  string
+		KeyPath   string
+		LegacyTLS bool
 	}
 
 	API struct {

--- a/v2/pkg/server/options.go
+++ b/v2/pkg/server/options.go
@@ -16,12 +16,13 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	Logger    zerolog.Logger
-	Config    *config.Config
-	TLSConfig *tls.Config
-	Monitor   monitoring.MonitorInterface
-	Tracer    trace.Tracer
-	Context   context.Context
+	Logger         zerolog.Logger
+	Config         *config.Config
+	StartTLSConfig *tls.Config
+	LDAPSTLSConfig *tls.Config
+	Monitor        monitoring.MonitorInterface
+	Tracer         trace.Tracer
+	Context        context.Context
 }
 
 // newOptions initializes the available default options.
@@ -56,10 +57,17 @@ func Context(val context.Context) Option {
 	}
 }
 
-// TLSConfig provides a function to set the TLS config option.
-func TLSConfig(val *tls.Config) Option {
+// TLSConfig provides a function to set the StartTLS config option.
+func StartTLSConfig(val *tls.Config) Option {
 	return func(o *Options) {
-		o.TLSConfig = val
+		o.StartTLSConfig = val
+	}
+}
+
+// TLSConfig provides a function to set the LDAPSTls config option.
+func LDAPSTLSConfig(val *tls.Config) Option {
+	return func(o *Options) {
+		o.LDAPSTLSConfig = val
 	}
 }
 

--- a/v2/pkg/server/server.go
+++ b/v2/pkg/server/server.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"plugin"
+
+	_tls "github.com/glauth/glauth/v2/internal/tls"
 
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/trace"
@@ -20,9 +23,10 @@ type LdapSvc struct {
 	yubiAuth *yubigo.YubiAuth
 	l        *ldap.Server
 
-	monitor monitoring.MonitorInterface
-	tracer  trace.Tracer
-	log     zerolog.Logger
+	ldapstls *tls.Config
+	monitor  monitoring.MonitorInterface
+	tracer   trace.Tracer
+	log      zerolog.Logger
 }
 
 func NewServer(opts ...Option) (*LdapSvc, error) {
@@ -96,9 +100,22 @@ func NewServer(opts ...Option) (*LdapSvc, error) {
 	s.l = ldap.NewServer()
 	s.l.EnforceLDAP = true
 
-	if tlsConfig := options.TLSConfig; tlsConfig != nil {
+	if tlsConfig := options.StartTLSConfig; tlsConfig != nil {
 		s.l.TLSConfig = tlsConfig
-		s.log.Info().Interface("tls.certificates", tlsConfig.Certificates).Msg("enabling LDAP over TLS")
+		s.log.Info().
+			Str("tls.min_version", tls.VersionName(tlsConfig.MinVersion)).
+			Str("tls.max_version", tls.VersionName(tlsConfig.MaxVersion)).
+			Interface("tls.cipher_suites", _tls.CipherSuiteNames(tlsConfig.CipherSuites)).
+			Msg("enabling LDAP over TLS")
+	}
+
+	if tlsConfig := options.LDAPSTLSConfig; tlsConfig != nil {
+		s.ldapstls = tlsConfig
+		s.log.Info().
+			Str("tls.min_version", tls.VersionName(tlsConfig.MinVersion)).
+			Str("tls.max_version", tls.VersionName(tlsConfig.MaxVersion)).
+			Interface("tls.cipher_suites", _tls.CipherSuiteNames(tlsConfig.CipherSuites)).
+			Msg("enabling LDAPS")
 	}
 
 	for i, backend := range s.c.Backends {
@@ -199,11 +216,11 @@ func (s *LdapSvc) ListenAndServe() error {
 // ListenAndServeTLS listens on the TCP network address s.c.LDAPS.Listen
 func (s *LdapSvc) ListenAndServeTLS() error {
 	s.log.Info().Str("address", s.c.LDAPS.Listen).Msg("LDAPS server listening")
-	return s.l.ListenAndServeTLS(
-		s.c.LDAPS.Listen,
-		s.c.LDAPS.Cert,
-		s.c.LDAPS.Key,
-	)
+	listener, err := tls.Listen("tcp", s.c.LDAPS.Listen, s.ldapstls)
+	if err != nil {
+		return err
+	}
+	return s.l.Serve(listener)
 }
 
 // Shutdown ends listeners by sending true to the ldap serves quit channel


### PR DESCRIPTION
This PR handles a few things:

- application of the patch by @hth2, allowing LDAP to only accept secure ciphers and TLS >= 1.2
- Alessandro's starttls introduction, 2 years ago (already?!)
- fixing above patch as there was confusion between starttls and ldaps code
- making sure both functionalities can be configured similarly
- couple minor logic things
- backward compatibility: cert and key configuration can now represent content, or file path (legacy)
- backward compatibility: legacy configuration parameter, allowing all ciphers/TLS1.0 (but don't!)