### PR TITLE
Use dynamic GOOS and GOARCH in integration-test.sh

### DIFF
--- a/v2/scripts/ci/integration-test.sh
+++ b/v2/scripts/ci/integration-test.sh
@@ -33,14 +33,14 @@ fi
 echo "";
 echo ""
 echo "Version string of tested binary:"
-"$CI_BUILD_DIR/bin/linuxamd64/glauth" --version
+"$CI_BUILD_DIR/bin/$(go env GOOS)$(go env GOARCH)/glauth" --version
 echo ""
 
 # Start in background, capture PID
-"$CI_BUILD_DIR/bin/linuxamd64/glauth" -c "$CI_BUILD_DIR/scripts/ci/test-config.cfg" &> /dev/null &
+"$CI_BUILD_DIR/bin/$(go env GOOS)$(go env GOARCH)/glauth" -c "$CI_BUILD_DIR/scripts/ci/test-config.cfg" &> /dev/null &
 
 # Use this instead to see glauth logs while running
-# "$CI_BUILD_DIR/bin/linuxamd64/glauth" -c "$CI_BUILD_DIR/scripts/ci/test-config.cfg" &
+# "$CI_BUILD_DIR/bin/$(go env GOOS)$(go env GOARCH)/glauth" -c "$CI_BUILD_DIR/scripts/ci/test-config.cfg" &
 glauthPid="$!"
 
 echo "Running glauth at PID=$glauthPid"


### PR DESCRIPTION
Drop hard-coded linuxamd64 from path in v2/scripts/ci/integration-test.sh and use instead dynamic GOOS and GOARCH env.

Resolves: #463 